### PR TITLE
feat(xmldsig): verify x509 certificate chains

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,10 @@ base64 = "0.22"
 # Error handling
 thiserror = "2"
 
+[dev-dependencies]
+rcgen = "0.14.6"
+time = "0.3"
+
 [features]
 default = ["xmldsig", "c14n"]
 xmldsig = [            # XML Digital Signatures (sign + verify)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ signature = { version = "3", optional = true }
 subtle = { version = "2", optional = true }
 
 # X.509 certificates
-x509-parser = { version = "0.18", optional = true }
+x509-parser = { version = "0.18", features = ["verify"], optional = true }
 der = { version = "0.8", optional = true }
 
 # Base64 encoding/decoding

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Currently implemented (core paths):
 - XMLDSig full verify pipeline (`SignedInfo` canonicalization + `SignatureValue` verification)
 - RSA PKCS#1 v1.5 verification helpers for SHA-1 / SHA-256 / SHA-384 / SHA-512
 - ECDSA verification helpers for P-256/SHA-256 and P-384/SHA-384
+- Opt-in X.509 certificate-chain validation with explicit trust anchors, validity checks, CA constraints, and CRLs
 
 Still in progress:
 - XMLDSig signing pipeline

--- a/src/xmldsig/mod.rs
+++ b/src/xmldsig/mod.rs
@@ -16,6 +16,7 @@ pub mod types;
 pub mod uri;
 pub mod verify;
 pub(crate) mod whitespace;
+pub mod x509;
 
 pub use digest::{DigestAlgorithm, compute_digest, constant_time_eq};
 pub use parse::{
@@ -36,3 +37,4 @@ pub use verify::{
     ReferenceSet, ReferencesResult, UriTypeSet, VerifyContext, VerifyResult, VerifyingKey,
     process_all_references, process_reference, verify_signature_with_pem_key,
 };
+pub use x509::{X509ChainError, X509ChainOptions, verify_x509_certificate_chain};

--- a/src/xmldsig/x509.rs
+++ b/src/xmldsig/x509.rs
@@ -116,9 +116,15 @@ pub fn verify_x509_certificate_chain(
         return validate_path(&path_der, info, options, verification_time);
     }
 
-    let replace_untrusted_root = path_der.len() > 1
+    let replace_untrusted_root = if path_der.len() > 1
         && last.subject() == last.issuer()
-        && last.verify_signature(None).is_ok();
+        && last.verify_signature(None).is_ok()
+    {
+        let child = parse_certificate(path_der[path_der.len() - 2])?;
+        child.issuer() == last.subject() && child.verify_signature(Some(last.public_key())).is_ok()
+    } else {
+        false
+    };
     let candidate_base = if replace_untrusted_root {
         &path_der[..path_der.len() - 1]
     } else {

--- a/src/xmldsig/x509.rs
+++ b/src/xmldsig/x509.rs
@@ -57,6 +57,14 @@ pub enum X509ChainError {
         /// Maximum permitted subordinate CA count.
         limit: u32,
     },
+    /// A certificate key usage extension forbids the required operation.
+    #[error("certificate at chain position {position} does not permit {required}")]
+    InvalidKeyUsage {
+        /// Position of the certificate in the validated path.
+        position: usize,
+        /// RFC 5280 key usage required for the operation.
+        required: &'static str,
+    },
     /// A certificate signature does not verify under its issuer key.
     #[error("certificate signature at chain position {0} is invalid or unsupported")]
     InvalidSignature(usize),
@@ -96,17 +104,22 @@ pub fn verify_x509_certificate_chain(
             .copied()
             .ok_or(X509ChainError::UntrustedRoot)?,
     )?;
-    let embedded_anchor = options
+    let trusted_anchors = options
         .trusted_certs
         .iter()
-        .any(|anchor| anchor.as_slice() == last.as_raw());
+        .map(|der| parse_certificate(der).map(|cert| (der, cert)))
+        .collect::<Result<Vec<_>, _>>()?;
+    let embedded_anchor = trusted_anchors
+        .iter()
+        .any(|(der, _)| der.as_slice() == last.as_raw());
     if !embedded_anchor {
-        let anchor = options
-            .trusted_certs
+        let anchor = trusted_anchors
             .iter()
-            .find(|anchor| {
-                parse_certificate(anchor).is_ok_and(|cert| cert.subject() == last.issuer())
+            .find(|(_, cert)| {
+                cert.subject() == last.issuer()
+                    && last.verify_signature(Some(cert.public_key())).is_ok()
             })
+            .map(|(der, _)| *der)
             .ok_or(X509ChainError::UntrustedRoot)?;
         path_der.push(anchor);
     }
@@ -188,6 +201,20 @@ fn validate_ca_constraints(
         .filter(|constraints| constraints.ca)
         .ok_or(X509ChainError::IssuerNotCa(position))?;
 
+    if cert
+        .key_usage()
+        .map_err(|error| X509ChainError::InvalidDer {
+            kind: "certificate KeyUsage",
+            message: error.to_string(),
+        })?
+        .is_some_and(|usage| !usage.value.key_cert_sign())
+    {
+        return Err(X509ChainError::InvalidKeyUsage {
+            position,
+            required: "keyCertSign",
+        });
+    }
+
     if let Some(limit) = constraints.path_len_constraint {
         let subordinate_ca_count = position.saturating_sub(1);
         if subordinate_ca_count > limit as usize {
@@ -225,6 +252,19 @@ fn verify_crls(
     for (position, cert) in path.iter().enumerate().take(path.len().saturating_sub(1)) {
         let issuer = &path[position + 1];
         for (crl_index, crl) in crls.iter().filter(|(_, crl)| crl.issuer() == cert.issuer()) {
+            if issuer
+                .key_usage()
+                .map_err(|error| X509ChainError::InvalidDer {
+                    kind: "certificate KeyUsage",
+                    message: error.to_string(),
+                })?
+                .is_some_and(|usage| !usage.value.crl_sign())
+            {
+                return Err(X509ChainError::InvalidKeyUsage {
+                    position: position + 1,
+                    required: "cRLSign",
+                });
+            }
             let time_valid = crl.last_update() <= verification_time
                 && crl
                     .next_update()

--- a/src/xmldsig/x509.rs
+++ b/src/xmldsig/x509.rs
@@ -116,11 +116,29 @@ pub fn verify_x509_certificate_chain(
         return validate_path(&path_der, info, options, verification_time);
     }
 
+    let replace_untrusted_root = path_der.len() > 1
+        && last.subject() == last.issuer()
+        && last.verify_signature(None).is_ok();
+    let candidate_base = if replace_untrusted_root {
+        &path_der[..path_der.len() - 1]
+    } else {
+        path_der.as_slice()
+    };
+    let candidate_child = parse_certificate(
+        candidate_base
+            .last()
+            .copied()
+            .ok_or(X509ChainError::UntrustedRoot)?,
+    )?;
+
     let mut first_validation_error = None;
     for (anchor_der, _) in trusted_anchors.iter().filter(|(_, cert)| {
-        cert.subject() == last.issuer() && last.verify_signature(Some(cert.public_key())).is_ok()
+        cert.subject() == candidate_child.issuer()
+            && candidate_child
+                .verify_signature(Some(cert.public_key()))
+                .is_ok()
     }) {
-        let mut candidate_path = path_der.clone();
+        let mut candidate_path = candidate_base.to_vec();
         candidate_path.push(anchor_der);
         match validate_path(&candidate_path, info, options, verification_time) {
             Ok(()) => return Ok(()),
@@ -175,6 +193,7 @@ fn validate_path(
 }
 
 fn validate_leaf_key_usage(cert: &X509Certificate<'_>) -> Result<(), X509ChainError> {
+    // RFC 5280 section 4.2.1.3 restricts key purpose only when KeyUsage is present.
     if cert
         .key_usage()
         .map_err(|error| X509ChainError::InvalidDer {

--- a/src/xmldsig/x509.rs
+++ b/src/xmldsig/x509.rs
@@ -1,0 +1,244 @@
+//! X.509 certificate path and revocation validation.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use x509_parser::{
+    certificate::X509Certificate, extensions::ParsedExtension, prelude::FromDer,
+    revocation_list::CertificateRevocationList, time::ASN1Time,
+};
+
+use super::X509DataInfo;
+
+/// Inputs controlling X.509 certificate-chain validation.
+#[derive(Debug, Clone)]
+pub struct X509ChainOptions<'a> {
+    /// DER-encoded certificates accepted as trust anchors.
+    pub trusted_certs: &'a [Vec<u8>],
+    /// Time used for certificate, CRL, and revocation checks.
+    pub verification_time: SystemTime,
+    /// Maximum number of certificates in the validated path, including the anchor.
+    pub max_chain_depth: usize,
+    /// Whether parsed `<X509CRL>` entries are enforced.
+    pub check_crls: bool,
+}
+
+/// Certificate-chain validation failure.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum X509ChainError {
+    /// The configured path limit cannot contain a certificate.
+    #[error("maximum certificate chain depth must be greater than zero")]
+    InvalidDepth,
+    /// A certificate or CRL is malformed DER.
+    #[error("invalid {kind} DER: {message}")]
+    InvalidDer {
+        /// Object type being parsed.
+        kind: &'static str,
+        /// Parser diagnostic.
+        message: String,
+    },
+    /// The ordered embedded path cannot be completed to a configured anchor.
+    #[error("certificate chain does not terminate at a trusted certificate")]
+    UntrustedRoot,
+    /// The path contains more certificates than allowed.
+    #[error("certificate chain exceeds maximum depth of {0}")]
+    DepthExceeded(usize),
+    /// A certificate is outside its validity period.
+    #[error("certificate at chain position {0} is expired or not yet valid")]
+    CertificateNotValid(usize),
+    /// An issuer certificate is not authorized to issue certificates.
+    #[error("certificate at chain position {0} is not a CA")]
+    IssuerNotCa(usize),
+    /// A CA path-length constraint is violated.
+    #[error("certificate at chain position {position} exceeds path length constraint {limit}")]
+    PathLengthExceeded {
+        /// Position of the constraining CA certificate.
+        position: usize,
+        /// Maximum permitted subordinate CA count.
+        limit: u32,
+    },
+    /// A certificate signature does not verify under its issuer key.
+    #[error("certificate signature at chain position {0} is invalid or unsupported")]
+    InvalidSignature(usize),
+    /// A CRL is not valid for the selected verification time or issuer.
+    #[error("CRL {0} is invalid or cannot be authenticated")]
+    InvalidCrl(usize),
+    /// A path certificate was revoked by an applicable CRL.
+    #[error("certificate at chain position {0} is revoked")]
+    Revoked(usize),
+}
+
+/// Verify the ordered certificate path parsed from one `<X509Data>` element.
+pub fn verify_x509_certificate_chain(
+    info: &X509DataInfo,
+    options: &X509ChainOptions<'_>,
+) -> Result<(), X509ChainError> {
+    if options.max_chain_depth == 0 {
+        return Err(X509ChainError::InvalidDepth);
+    }
+    if info.certificate_chain.is_empty() {
+        return Err(X509ChainError::UntrustedRoot);
+    }
+
+    let mut path_der = info
+        .certificate_chain
+        .iter()
+        .map(|&idx| {
+            info.certificates
+                .get(idx)
+                .ok_or(X509ChainError::UntrustedRoot)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let last = parse_certificate(
+        path_der
+            .last()
+            .copied()
+            .ok_or(X509ChainError::UntrustedRoot)?,
+    )?;
+    let embedded_anchor = options
+        .trusted_certs
+        .iter()
+        .any(|anchor| anchor.as_slice() == last.as_raw());
+    if !embedded_anchor {
+        let anchor = options
+            .trusted_certs
+            .iter()
+            .find(|anchor| {
+                parse_certificate(anchor).is_ok_and(|cert| cert.subject() == last.issuer())
+            })
+            .ok_or(X509ChainError::UntrustedRoot)?;
+        path_der.push(anchor);
+    }
+
+    if path_der.len() > options.max_chain_depth {
+        return Err(X509ChainError::DepthExceeded(options.max_chain_depth));
+    }
+
+    let path = path_der
+        .iter()
+        .map(|der| parse_certificate(der))
+        .collect::<Result<Vec<_>, _>>()?;
+    let verification_time = system_time_to_asn1(options.verification_time)?;
+
+    for (position, cert) in path.iter().enumerate() {
+        if !cert.validity().is_valid_at(verification_time) {
+            return Err(X509ChainError::CertificateNotValid(position));
+        }
+        if position > 0 {
+            validate_ca_constraints(cert, position)?;
+        }
+    }
+
+    for (position, pair) in path.windows(2).enumerate() {
+        let [child, issuer] = pair else {
+            unreachable!()
+        };
+        if child.issuer() != issuer.subject()
+            || child.verify_signature(Some(issuer.public_key())).is_err()
+        {
+            return Err(X509ChainError::InvalidSignature(position));
+        }
+    }
+
+    if options.check_crls {
+        verify_crls(&path, &info.crls, verification_time)?;
+    }
+    Ok(())
+}
+
+fn parse_certificate(der: &[u8]) -> Result<X509Certificate<'_>, X509ChainError> {
+    let (rest, cert) =
+        X509Certificate::from_der(der).map_err(|error| X509ChainError::InvalidDer {
+            kind: "certificate",
+            message: error.to_string(),
+        })?;
+    if !rest.is_empty() {
+        return Err(X509ChainError::InvalidDer {
+            kind: "certificate",
+            message: "trailing data".into(),
+        });
+    }
+    Ok(cert)
+}
+
+fn system_time_to_asn1(time: SystemTime) -> Result<ASN1Time, X509ChainError> {
+    let seconds = time
+        .duration_since(UNIX_EPOCH)
+        .map_err(|_| X509ChainError::CertificateNotValid(0))?
+        .as_secs();
+    let timestamp = i64::try_from(seconds).map_err(|_| X509ChainError::CertificateNotValid(0))?;
+    ASN1Time::from_timestamp(timestamp).map_err(|error| X509ChainError::InvalidDer {
+        kind: "verification time",
+        message: error.to_string(),
+    })
+}
+
+fn validate_ca_constraints(
+    cert: &X509Certificate<'_>,
+    position: usize,
+) -> Result<(), X509ChainError> {
+    let constraints = cert
+        .extensions()
+        .iter()
+        .find_map(|extension| match extension.parsed_extension() {
+            ParsedExtension::BasicConstraints(value) => Some(value),
+            _ => None,
+        })
+        .filter(|constraints| constraints.ca)
+        .ok_or(X509ChainError::IssuerNotCa(position))?;
+
+    if let Some(limit) = constraints.path_len_constraint {
+        let subordinate_ca_count = position.saturating_sub(1);
+        if subordinate_ca_count > limit as usize {
+            return Err(X509ChainError::PathLengthExceeded { position, limit });
+        }
+    }
+    Ok(())
+}
+
+fn verify_crls(
+    path: &[X509Certificate<'_>],
+    crl_der: &[Vec<u8>],
+    verification_time: ASN1Time,
+) -> Result<(), X509ChainError> {
+    let crls = crl_der
+        .iter()
+        .enumerate()
+        .map(|(idx, der)| {
+            let (rest, crl) = CertificateRevocationList::from_der(der).map_err(|error| {
+                X509ChainError::InvalidDer {
+                    kind: "CRL",
+                    message: error.to_string(),
+                }
+            })?;
+            if !rest.is_empty() {
+                return Err(X509ChainError::InvalidDer {
+                    kind: "CRL",
+                    message: "trailing data".into(),
+                });
+            }
+            Ok((idx, crl))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    for (position, cert) in path.iter().enumerate().take(path.len().saturating_sub(1)) {
+        let issuer = &path[position + 1];
+        for (crl_index, crl) in crls.iter().filter(|(_, crl)| crl.issuer() == cert.issuer()) {
+            let time_valid = crl.last_update() <= verification_time
+                && crl
+                    .next_update()
+                    .is_none_or(|next| verification_time <= next);
+            if !time_valid || crl.verify_signature(issuer.public_key()).is_err() {
+                return Err(X509ChainError::InvalidCrl(*crl_index));
+            }
+            if crl.iter_revoked_certificates().any(|revoked| {
+                revoked.raw_serial() == cert.raw_serial()
+                    && revoked.revocation_date <= verification_time
+            }) {
+                return Err(X509ChainError::Revoked(position));
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/xmldsig/x509.rs
+++ b/src/xmldsig/x509.rs
@@ -88,12 +88,13 @@ pub fn verify_x509_certificate_chain(
         return Err(X509ChainError::UntrustedRoot);
     }
 
-    let mut path_der = info
+    let path_der = info
         .certificate_chain
         .iter()
         .map(|&idx| {
             info.certificates
                 .get(idx)
+                .map(Vec::as_slice)
                 .ok_or(X509ChainError::UntrustedRoot)
         })
         .collect::<Result<Vec<_>, _>>()?;
@@ -107,23 +108,35 @@ pub fn verify_x509_certificate_chain(
     let trusted_anchors = options
         .trusted_certs
         .iter()
-        .map(|der| parse_certificate(der).map(|cert| (der, cert)))
+        .map(|der| parse_certificate(der).map(|cert| (der.as_slice(), cert)))
         .collect::<Result<Vec<_>, _>>()?;
-    let embedded_anchor = trusted_anchors
-        .iter()
-        .any(|(der, _)| der.as_slice() == last.as_raw());
-    if !embedded_anchor {
-        let anchor = trusted_anchors
-            .iter()
-            .find(|(_, cert)| {
-                cert.subject() == last.issuer()
-                    && last.verify_signature(Some(cert.public_key())).is_ok()
-            })
-            .map(|(der, _)| *der)
-            .ok_or(X509ChainError::UntrustedRoot)?;
-        path_der.push(anchor);
+    let verification_time = system_time_to_asn1(options.verification_time)?;
+    let embedded_anchor = trusted_anchors.iter().any(|(der, _)| *der == last.as_raw());
+    if embedded_anchor {
+        return validate_path(&path_der, info, options, verification_time);
     }
 
+    let mut first_validation_error = None;
+    for (anchor_der, _) in trusted_anchors.iter().filter(|(_, cert)| {
+        cert.subject() == last.issuer() && last.verify_signature(Some(cert.public_key())).is_ok()
+    }) {
+        let mut candidate_path = path_der.clone();
+        candidate_path.push(anchor_der);
+        match validate_path(&candidate_path, info, options, verification_time) {
+            Ok(()) => return Ok(()),
+            Err(error) => first_validation_error.get_or_insert(error),
+        };
+    }
+
+    Err(first_validation_error.unwrap_or(X509ChainError::UntrustedRoot))
+}
+
+fn validate_path(
+    path_der: &[&[u8]],
+    info: &X509DataInfo,
+    options: &X509ChainOptions<'_>,
+    verification_time: ASN1Time,
+) -> Result<(), X509ChainError> {
     if path_der.len() > options.max_chain_depth {
         return Err(X509ChainError::DepthExceeded(options.max_chain_depth));
     }
@@ -132,13 +145,14 @@ pub fn verify_x509_certificate_chain(
         .iter()
         .map(|der| parse_certificate(der))
         .collect::<Result<Vec<_>, _>>()?;
-    let verification_time = system_time_to_asn1(options.verification_time)?;
 
     for (position, cert) in path.iter().enumerate() {
         if !cert.validity().is_valid_at(verification_time) {
             return Err(X509ChainError::CertificateNotValid(position));
         }
-        if position > 0 {
+        if position == 0 {
+            validate_leaf_key_usage(cert)?;
+        } else {
             validate_ca_constraints(cert, position)?;
         }
     }
@@ -156,6 +170,23 @@ pub fn verify_x509_certificate_chain(
 
     if options.check_crls {
         verify_crls(&path, &info.crls, verification_time)?;
+    }
+    Ok(())
+}
+
+fn validate_leaf_key_usage(cert: &X509Certificate<'_>) -> Result<(), X509ChainError> {
+    if cert
+        .key_usage()
+        .map_err(|error| X509ChainError::InvalidDer {
+            kind: "certificate KeyUsage",
+            message: error.to_string(),
+        })?
+        .is_some_and(|usage| !usage.value.digital_signature() && !usage.value.non_repudiation())
+    {
+        return Err(X509ChainError::InvalidKeyUsage {
+            position: 0,
+            required: "digitalSignature or nonRepudiation",
+        });
     }
     Ok(())
 }

--- a/tests/x509_chain_integration.rs
+++ b/tests/x509_chain_integration.rs
@@ -5,6 +5,10 @@ use std::{
 };
 
 use base64::{Engine as _, engine::general_purpose::STANDARD};
+use rcgen::{
+    BasicConstraints, CertificateParams, CertificateRevocationListParams, IsCa, Issuer,
+    KeyIdMethod, KeyPair, KeyUsagePurpose, SerialNumber, date_time_ymd,
+};
 use roxmltree::Document;
 use xml_sec::xmldsig::{
     KeyInfoSource, X509ChainError, X509ChainOptions, X509DataInfo, parse_key_info,
@@ -80,6 +84,52 @@ fn options<'a>(trusted_certs: &'a [Vec<u8>], check_crls: bool) -> X509ChainOptio
     }
 }
 
+fn generated_chain(
+    root_constraints: BasicConstraints,
+    intermediate_is_ca: IsCa,
+    intermediate_key_usages: Vec<KeyUsagePurpose>,
+) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+    let mut root_params = CertificateParams::new(Vec::new()).unwrap();
+    root_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "root");
+    root_params.is_ca = IsCa::Ca(root_constraints);
+    root_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+    let root =
+        rcgen::CertifiedIssuer::self_signed(root_params, KeyPair::generate().unwrap()).unwrap();
+
+    let mut intermediate_params = CertificateParams::new(Vec::new()).unwrap();
+    intermediate_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "intermediate");
+    intermediate_params.is_ca = intermediate_is_ca;
+    intermediate_params.key_usages = intermediate_key_usages;
+    let intermediate =
+        rcgen::CertifiedIssuer::signed_by(intermediate_params, KeyPair::generate().unwrap(), &root)
+            .unwrap();
+
+    let mut leaf_params = CertificateParams::new(Vec::new()).unwrap();
+    leaf_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "leaf");
+    let leaf = leaf_params
+        .signed_by(&KeyPair::generate().unwrap(), &intermediate)
+        .unwrap();
+
+    (
+        leaf.der().to_vec(),
+        intermediate.der().to_vec(),
+        root.der().to_vec(),
+    )
+}
+
+fn generated_info(certificates: Vec<Vec<u8>>) -> X509DataInfo {
+    let mut info = X509DataInfo::default();
+    info.certificate_chain = (0..certificates.len()).collect();
+    info.certificates = certificates;
+    info
+}
+
 #[test]
 fn validates_unordered_chain_against_explicit_anchor() {
     let info = parsed_chain("rsa/rsa-2048-cert.pem", None);
@@ -88,6 +138,120 @@ fn validates_unordered_chain_against_explicit_anchor() {
     assert_eq!(
         verify_x509_certificate_chain(&info, &options(&anchors, false)),
         Ok(())
+    );
+}
+
+#[test]
+fn validates_chain_completed_by_external_anchor() {
+    let (leaf, intermediate, root) = generated_chain(
+        BasicConstraints::Unconstrained,
+        IsCa::Ca(BasicConstraints::Unconstrained),
+        vec![KeyUsagePurpose::KeyCertSign],
+    );
+    let info = generated_info(vec![leaf, intermediate]);
+    let anchors = [root];
+
+    assert_eq!(
+        verify_x509_certificate_chain(&info, &options(&anchors, false)),
+        Ok(())
+    );
+}
+
+#[test]
+fn rejects_malformed_configured_anchor_even_when_another_anchor_matches() {
+    let info = parsed_chain("rsa/rsa-2048-cert.pem", None);
+    let anchors = [vec![1, 2, 3], fixture("cacert.pem")];
+
+    assert!(matches!(
+        verify_x509_certificate_chain(&info, &options(&anchors, false)),
+        Err(X509ChainError::InvalidDer {
+            kind: "certificate",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn selects_signature_verifying_anchor_when_subjects_match() {
+    let mut first_params = CertificateParams::new(Vec::new()).unwrap();
+    first_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "shared root");
+    first_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    first_params.key_usages = vec![KeyUsagePurpose::KeyCertSign];
+    let first =
+        rcgen::CertifiedIssuer::self_signed(first_params, KeyPair::generate().unwrap()).unwrap();
+
+    let mut second_params = CertificateParams::new(Vec::new()).unwrap();
+    second_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "shared root");
+    second_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    second_params.key_usages = vec![KeyUsagePurpose::KeyCertSign];
+    let second =
+        rcgen::CertifiedIssuer::self_signed(second_params, KeyPair::generate().unwrap()).unwrap();
+
+    let mut leaf_params = CertificateParams::new(Vec::new()).unwrap();
+    leaf_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "leaf");
+    let leaf = leaf_params
+        .signed_by(&KeyPair::generate().unwrap(), &second)
+        .unwrap();
+    let info = generated_info(vec![leaf.der().to_vec()]);
+    let anchors = [first.der().to_vec(), second.der().to_vec()];
+
+    assert_eq!(
+        verify_x509_certificate_chain(&info, &options(&anchors, false)),
+        Ok(())
+    );
+}
+
+#[test]
+fn rejects_non_ca_issuer() {
+    let (leaf, intermediate, root) = generated_chain(
+        BasicConstraints::Unconstrained,
+        IsCa::NoCa,
+        vec![KeyUsagePurpose::KeyCertSign],
+    );
+    let info = generated_info(vec![leaf, intermediate, root.clone()]);
+    let anchors = [root];
+
+    assert_eq!(
+        verify_x509_certificate_chain(&info, &options(&anchors, false)),
+        Err(X509ChainError::IssuerNotCa(1))
+    );
+}
+
+#[test]
+fn rejects_ca_without_key_cert_sign_usage() {
+    let (leaf, intermediate, root) = generated_chain(
+        BasicConstraints::Unconstrained,
+        IsCa::Ca(BasicConstraints::Unconstrained),
+        vec![KeyUsagePurpose::DigitalSignature],
+    );
+    let info = generated_info(vec![leaf, intermediate, root.clone()]);
+    let anchors = [root];
+
+    assert!(verify_x509_certificate_chain(&info, &options(&anchors, false)).is_err());
+}
+
+#[test]
+fn rejects_path_length_constraint_violation() {
+    let (leaf, intermediate, root) = generated_chain(
+        BasicConstraints::Constrained(0),
+        IsCa::Ca(BasicConstraints::Unconstrained),
+        vec![KeyUsagePurpose::KeyCertSign],
+    );
+    let info = generated_info(vec![leaf, intermediate, root.clone()]);
+    let anchors = [root];
+
+    assert_eq!(
+        verify_x509_certificate_chain(&info, &options(&anchors, false)),
+        Err(X509ChainError::PathLengthExceeded {
+            position: 2,
+            limit: 0
+        })
     );
 }
 
@@ -176,4 +340,60 @@ fn rejects_malformed_crl_when_revocation_checking_is_enabled() {
         verify_x509_certificate_chain(&info, &options(&anchors, true)),
         Err(X509ChainError::InvalidDer { kind: "CRL", .. })
     ));
+}
+
+#[test]
+fn rejects_crl_signed_by_certificate_without_crl_sign_usage() {
+    let mut root_params = CertificateParams::new(Vec::new()).unwrap();
+    root_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "root");
+    root_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    root_params.key_usages = vec![KeyUsagePurpose::KeyCertSign];
+    let root =
+        rcgen::CertifiedIssuer::self_signed(root_params, KeyPair::generate().unwrap()).unwrap();
+
+    let issuer_key = KeyPair::generate().unwrap();
+    let mut cert_params = CertificateParams::new(Vec::new()).unwrap();
+    cert_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "issuer");
+    cert_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    cert_params.key_usages = vec![KeyUsagePurpose::KeyCertSign];
+    let issuer_cert = cert_params.signed_by(&issuer_key, &root).unwrap();
+
+    let mut signing_params = CertificateParams::new(Vec::new()).unwrap();
+    signing_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "issuer");
+    signing_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    signing_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+    let issuer = Issuer::new(signing_params, issuer_key);
+
+    let mut leaf_params = CertificateParams::new(Vec::new()).unwrap();
+    leaf_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "leaf");
+    let leaf = leaf_params
+        .signed_by(&KeyPair::generate().unwrap(), &issuer)
+        .unwrap();
+    let crl = CertificateRevocationListParams {
+        this_update: date_time_ymd(2026, 3, 15),
+        next_update: date_time_ymd(2026, 4, 15),
+        crl_number: SerialNumber::from(1_u64),
+        issuing_distribution_point: None,
+        revoked_certs: Vec::new(),
+        key_identifier_method: KeyIdMethod::Sha256,
+    }
+    .signed_by(&issuer)
+    .unwrap();
+    let mut info = generated_info(vec![
+        leaf.der().to_vec(),
+        issuer_cert.der().to_vec(),
+        root.der().to_vec(),
+    ]);
+    info.crls.push(crl.der().to_vec());
+    let anchors = [root.der().to_vec()];
+
+    assert!(verify_x509_certificate_chain(&info, &options(&anchors, true)).is_err());
 }

--- a/tests/x509_chain_integration.rs
+++ b/tests/x509_chain_integration.rs
@@ -265,6 +265,7 @@ fn rejects_leaf_without_signature_key_usage() {
     leaf_params
         .distinguished_name
         .push(rcgen::DnType::CommonName, "leaf");
+    leaf_params.is_ca = IsCa::ExplicitNoCa;
     leaf_params.key_usages = vec![KeyUsagePurpose::KeyEncipherment];
     let leaf = leaf_params
         .signed_by(&KeyPair::generate().unwrap(), &root)

--- a/tests/x509_chain_integration.rs
+++ b/tests/x509_chain_integration.rs
@@ -1,0 +1,179 @@
+use std::{
+    fs,
+    path::Path,
+    time::{Duration, UNIX_EPOCH},
+};
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use roxmltree::Document;
+use xml_sec::xmldsig::{
+    KeyInfoSource, X509ChainError, X509ChainOptions, X509DataInfo, parse_key_info,
+    verify_x509_certificate_chain,
+};
+
+const VERIFICATION_TIME: u64 = 1_773_964_800; // 2026-03-20T00:00:00Z
+
+fn pem_der(path: impl AsRef<Path>) -> Vec<u8> {
+    let pem = fs::read_to_string(path).expect("fixture PEM should be readable");
+    let mut inside_pem = false;
+    let payload = pem
+        .lines()
+        .filter(|line| {
+            if line.starts_with("-----BEGIN ") {
+                inside_pem = true;
+                return false;
+            }
+            if line.starts_with("-----END ") {
+                inside_pem = false;
+                return false;
+            }
+            inside_pem
+        })
+        .collect::<String>();
+    STANDARD
+        .decode(payload)
+        .expect("fixture PEM should contain base64 DER")
+}
+
+fn fixture(path: &str) -> Vec<u8> {
+    pem_der(
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/keys")
+            .join(path),
+    )
+}
+
+fn parsed_chain(leaf_path: &str, crl: Option<Vec<u8>>) -> X509DataInfo {
+    let leaf = STANDARD.encode(fixture(leaf_path));
+    let intermediate = STANDARD.encode(fixture("ca2cert.pem"));
+    let root = STANDARD.encode(fixture("cacert.pem"));
+    let crl = crl
+        .map(|der| format!("<X509CRL>{}</X509CRL>", STANDARD.encode(der)))
+        .unwrap_or_default();
+    let xml = format!(
+        r#"<KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#"><X509Data>
+            <X509Certificate>{root}</X509Certificate>
+            <X509Certificate>{leaf}</X509Certificate>
+            <X509Certificate>{intermediate}</X509Certificate>
+            {crl}
+        </X509Data></KeyInfo>"#
+    );
+    let document = Document::parse(&xml).expect("fixture XML should parse");
+    let key_info = parse_key_info(document.root_element()).expect("fixture KeyInfo should parse");
+    match key_info
+        .sources
+        .into_iter()
+        .next()
+        .expect("X509Data source should exist")
+    {
+        KeyInfoSource::X509Data(info) => info,
+        other => panic!("expected X509Data, got {other:?}"),
+    }
+}
+
+fn options<'a>(trusted_certs: &'a [Vec<u8>], check_crls: bool) -> X509ChainOptions<'a> {
+    X509ChainOptions {
+        trusted_certs,
+        verification_time: UNIX_EPOCH + Duration::from_secs(VERIFICATION_TIME),
+        max_chain_depth: 3,
+        check_crls,
+    }
+}
+
+#[test]
+fn validates_unordered_chain_against_explicit_anchor() {
+    let info = parsed_chain("rsa/rsa-2048-cert.pem", None);
+    let anchors = [fixture("cacert.pem")];
+
+    assert_eq!(
+        verify_x509_certificate_chain(&info, &options(&anchors, false)),
+        Ok(())
+    );
+}
+
+#[test]
+fn rejects_chain_without_matching_trust_anchor() {
+    let info = parsed_chain("rsa/rsa-2048-cert.pem", None);
+
+    assert_eq!(
+        verify_x509_certificate_chain(&info, &options(&[], false)),
+        Err(X509ChainError::UntrustedRoot)
+    );
+}
+
+#[test]
+fn rejects_expired_leaf_at_selected_verification_time() {
+    let info = parsed_chain("rsa/rsa-expired-cert.pem", None);
+    let anchors = [fixture("cacert.pem")];
+    let mut expired_time = options(&anchors, false);
+    expired_time.verification_time = UNIX_EPOCH + Duration::from_secs(1_774_828_800);
+
+    assert_eq!(
+        verify_x509_certificate_chain(&info, &expired_time),
+        Err(X509ChainError::CertificateNotValid(0))
+    );
+}
+
+#[test]
+fn rejects_path_longer_than_configured_depth() {
+    let info = parsed_chain("rsa/rsa-2048-cert.pem", None);
+    let anchors = [fixture("cacert.pem")];
+    let mut limited = options(&anchors, false);
+    limited.max_chain_depth = 2;
+
+    assert_eq!(
+        verify_x509_certificate_chain(&info, &limited),
+        Err(X509ChainError::DepthExceeded(2))
+    );
+}
+
+#[test]
+fn rejects_certificate_with_tampered_signature() {
+    let mut info = parsed_chain("rsa/rsa-2048-cert.pem", None);
+    let leaf_index = info.certificate_chain[0];
+    let last_byte = info.certificates[leaf_index]
+        .last_mut()
+        .expect("fixture certificate should not be empty");
+    *last_byte ^= 1;
+    let anchors = [fixture("cacert.pem")];
+
+    assert_eq!(
+        verify_x509_certificate_chain(&info, &options(&anchors, false)),
+        Err(X509ChainError::InvalidSignature(0))
+    );
+}
+
+#[test]
+fn rejects_certificate_revoked_by_authenticated_crl() {
+    let crl = fixture("rsa/rsa-2048-cert-revoked-crl.pem");
+    let info = parsed_chain("rsa/rsa-2048-cert.pem", Some(crl));
+    let anchors = [fixture("cacert.pem")];
+
+    assert_eq!(
+        verify_x509_certificate_chain(&info, &options(&anchors, true)),
+        Err(X509ChainError::Revoked(0))
+    );
+}
+
+#[test]
+fn ignores_supplied_crl_when_revocation_checking_is_disabled() {
+    let crl = fixture("rsa/rsa-2048-cert-revoked-crl.pem");
+    let info = parsed_chain("rsa/rsa-2048-cert.pem", Some(crl));
+    let anchors = [fixture("cacert.pem")];
+
+    assert_eq!(
+        verify_x509_certificate_chain(&info, &options(&anchors, false)),
+        Ok(())
+    );
+}
+
+#[test]
+fn rejects_malformed_crl_when_revocation_checking_is_enabled() {
+    let info = parsed_chain("rsa/rsa-2048-cert.pem", Some(vec![1, 2, 3]));
+    let anchors = [fixture("cacert.pem")];
+
+    assert!(matches!(
+        verify_x509_certificate_chain(&info, &options(&anchors, true)),
+        Err(X509ChainError::InvalidDer { kind: "CRL", .. })
+    ));
+}

--- a/tests/x509_chain_integration.rs
+++ b/tests/x509_chain_integration.rs
@@ -208,6 +208,80 @@ fn selects_signature_verifying_anchor_when_subjects_match() {
 }
 
 #[test]
+fn selects_fully_valid_anchor_when_signing_keys_match() {
+    let anchor_key = KeyPair::generate().unwrap();
+    let anchor_key_der = anchor_key.serialize_der();
+
+    let mut expired_params = CertificateParams::new(Vec::new()).unwrap();
+    expired_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "shared root");
+    expired_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    expired_params.key_usages = vec![KeyUsagePurpose::KeyCertSign];
+    expired_params.not_before = date_time_ymd(2020, 1, 1);
+    expired_params.not_after = date_time_ymd(2021, 1, 1);
+    let expired = rcgen::CertifiedIssuer::self_signed(
+        expired_params,
+        KeyPair::try_from(anchor_key_der.as_slice()).unwrap(),
+    )
+    .unwrap();
+
+    let mut valid_params = CertificateParams::new(Vec::new()).unwrap();
+    valid_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "shared root");
+    valid_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    valid_params.key_usages = vec![KeyUsagePurpose::KeyCertSign];
+    let valid = rcgen::CertifiedIssuer::self_signed(valid_params, anchor_key).unwrap();
+
+    let mut leaf_params = CertificateParams::new(Vec::new()).unwrap();
+    leaf_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "leaf");
+    let leaf = leaf_params
+        .signed_by(&KeyPair::generate().unwrap(), &valid)
+        .unwrap();
+    let info = generated_info(vec![leaf.der().to_vec()]);
+    let anchors = [expired.der().to_vec(), valid.der().to_vec()];
+
+    assert_eq!(
+        verify_x509_certificate_chain(&info, &options(&anchors, false)),
+        Ok(())
+    );
+}
+
+#[test]
+fn rejects_leaf_without_signature_key_usage() {
+    let mut root_params = CertificateParams::new(Vec::new()).unwrap();
+    root_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "root");
+    root_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    root_params.key_usages = vec![KeyUsagePurpose::KeyCertSign];
+    let root =
+        rcgen::CertifiedIssuer::self_signed(root_params, KeyPair::generate().unwrap()).unwrap();
+
+    let mut leaf_params = CertificateParams::new(Vec::new()).unwrap();
+    leaf_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "leaf");
+    leaf_params.key_usages = vec![KeyUsagePurpose::KeyEncipherment];
+    let leaf = leaf_params
+        .signed_by(&KeyPair::generate().unwrap(), &root)
+        .unwrap();
+    let info = generated_info(vec![leaf.der().to_vec()]);
+    let anchors = [root.der().to_vec()];
+
+    assert_eq!(
+        verify_x509_certificate_chain(&info, &options(&anchors, false)),
+        Err(X509ChainError::InvalidKeyUsage {
+            position: 0,
+            required: "digitalSignature or nonRepudiation",
+        })
+    );
+}
+
+#[test]
 fn rejects_non_ca_issuer() {
     let (leaf, intermediate, root) = generated_chain(
         BasicConstraints::Unconstrained,

--- a/tests/x509_chain_integration.rs
+++ b/tests/x509_chain_integration.rs
@@ -311,6 +311,60 @@ fn replaces_embedded_rollover_root_with_trusted_anchor() {
 }
 
 #[test]
+fn rejects_unrelated_self_signed_certificate_at_path_tail() {
+    let mut root_params = CertificateParams::new(Vec::new()).unwrap();
+    root_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "trusted root");
+    root_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    root_params.key_usages = vec![KeyUsagePurpose::KeyCertSign];
+    let root =
+        rcgen::CertifiedIssuer::self_signed(root_params, KeyPair::generate().unwrap()).unwrap();
+
+    let mut intermediate_params = CertificateParams::new(Vec::new()).unwrap();
+    intermediate_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "intermediate");
+    intermediate_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    intermediate_params.key_usages = vec![KeyUsagePurpose::KeyCertSign];
+    let intermediate = rcgen::CertifiedIssuer::signed_by(
+        intermediate_params,
+        KeyPair::generate().unwrap(),
+        &root,
+    )
+    .unwrap();
+
+    let mut leaf_params = CertificateParams::new(Vec::new()).unwrap();
+    leaf_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "leaf");
+    let leaf = leaf_params
+        .signed_by(&KeyPair::generate().unwrap(), &intermediate)
+        .unwrap();
+
+    let mut unrelated_params = CertificateParams::new(Vec::new()).unwrap();
+    unrelated_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "unrelated root");
+    unrelated_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    unrelated_params.key_usages = vec![KeyUsagePurpose::KeyCertSign];
+    let unrelated =
+        rcgen::CertifiedIssuer::self_signed(unrelated_params, KeyPair::generate().unwrap()).unwrap();
+
+    let info = generated_info(vec![
+        leaf.der().to_vec(),
+        intermediate.der().to_vec(),
+        unrelated.der().to_vec(),
+    ]);
+    let anchors = [root.der().to_vec()];
+
+    assert_eq!(
+        verify_x509_certificate_chain(&info, &options(&anchors, false)),
+        Err(X509ChainError::UntrustedRoot)
+    );
+}
+
+#[test]
 fn rejects_leaf_without_signature_key_usage() {
     let mut root_params = CertificateParams::new(Vec::new()).unwrap();
     root_params

--- a/tests/x509_chain_integration.rs
+++ b/tests/x509_chain_integration.rs
@@ -251,6 +251,66 @@ fn selects_fully_valid_anchor_when_signing_keys_match() {
 }
 
 #[test]
+fn replaces_embedded_rollover_root_with_trusted_anchor() {
+    let root_key = KeyPair::generate().unwrap();
+    let root_key_der = root_key.serialize_der();
+
+    let mut expired_params = CertificateParams::new(Vec::new()).unwrap();
+    expired_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "shared root");
+    expired_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    expired_params.key_usages = vec![KeyUsagePurpose::KeyCertSign];
+    expired_params.not_before = date_time_ymd(2020, 1, 1);
+    expired_params.not_after = date_time_ymd(2021, 1, 1);
+    let expired = rcgen::CertifiedIssuer::self_signed(expired_params, root_key).unwrap();
+
+    let mut renewed_params = CertificateParams::new(Vec::new()).unwrap();
+    renewed_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "shared root");
+    renewed_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    renewed_params.key_usages = vec![KeyUsagePurpose::KeyCertSign];
+    let renewed = rcgen::CertifiedIssuer::self_signed(
+        renewed_params,
+        KeyPair::try_from(root_key_der.as_slice()).unwrap(),
+    )
+    .unwrap();
+
+    let mut intermediate_params = CertificateParams::new(Vec::new()).unwrap();
+    intermediate_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "intermediate");
+    intermediate_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    intermediate_params.key_usages = vec![KeyUsagePurpose::KeyCertSign];
+    let intermediate = rcgen::CertifiedIssuer::signed_by(
+        intermediate_params,
+        KeyPair::generate().unwrap(),
+        &expired,
+    )
+    .unwrap();
+
+    let mut leaf_params = CertificateParams::new(Vec::new()).unwrap();
+    leaf_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "leaf");
+    let leaf = leaf_params
+        .signed_by(&KeyPair::generate().unwrap(), &intermediate)
+        .unwrap();
+    let info = generated_info(vec![
+        leaf.der().to_vec(),
+        intermediate.der().to_vec(),
+        expired.der().to_vec(),
+    ]);
+    let anchors = [renewed.der().to_vec()];
+
+    assert_eq!(
+        verify_x509_certificate_chain(&info, &options(&anchors, false)),
+        Ok(())
+    );
+}
+
+#[test]
 fn rejects_leaf_without_signature_key_usage() {
     let mut root_params = CertificateParams::new(Vec::new()).unwrap();
     root_params

--- a/tests/x509_chain_integration.rs
+++ b/tests/x509_chain_integration.rs
@@ -327,12 +327,9 @@ fn rejects_unrelated_self_signed_certificate_at_path_tail() {
         .push(rcgen::DnType::CommonName, "intermediate");
     intermediate_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
     intermediate_params.key_usages = vec![KeyUsagePurpose::KeyCertSign];
-    let intermediate = rcgen::CertifiedIssuer::signed_by(
-        intermediate_params,
-        KeyPair::generate().unwrap(),
-        &root,
-    )
-    .unwrap();
+    let intermediate =
+        rcgen::CertifiedIssuer::signed_by(intermediate_params, KeyPair::generate().unwrap(), &root)
+            .unwrap();
 
     let mut leaf_params = CertificateParams::new(Vec::new()).unwrap();
     leaf_params
@@ -349,7 +346,8 @@ fn rejects_unrelated_self_signed_certificate_at_path_tail() {
     unrelated_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
     unrelated_params.key_usages = vec![KeyUsagePurpose::KeyCertSign];
     let unrelated =
-        rcgen::CertifiedIssuer::self_signed(unrelated_params, KeyPair::generate().unwrap()).unwrap();
+        rcgen::CertifiedIssuer::self_signed(unrelated_params, KeyPair::generate().unwrap())
+            .unwrap();
 
     let info = generated_info(vec![
         leaf.der().to_vec(),

--- a/tests/x509_chain_integration.rs
+++ b/tests/x509_chain_integration.rs
@@ -233,7 +233,13 @@ fn rejects_ca_without_key_cert_sign_usage() {
     let info = generated_info(vec![leaf, intermediate, root.clone()]);
     let anchors = [root];
 
-    assert!(verify_x509_certificate_chain(&info, &options(&anchors, false)).is_err());
+    assert_eq!(
+        verify_x509_certificate_chain(&info, &options(&anchors, false)),
+        Err(X509ChainError::InvalidKeyUsage {
+            position: 1,
+            required: "keyCertSign",
+        })
+    );
 }
 
 #[test]
@@ -395,5 +401,11 @@ fn rejects_crl_signed_by_certificate_without_crl_sign_usage() {
     info.crls.push(crl.der().to_vec());
     let anchors = [root.der().to_vec()];
 
-    assert!(verify_x509_certificate_chain(&info, &options(&anchors, true)).is_err());
+    assert_eq!(
+        verify_x509_certificate_chain(&info, &options(&anchors, true)),
+        Err(X509ChainError::InvalidKeyUsage {
+            position: 1,
+            required: "cRLSign",
+        })
+    );
 }


### PR DESCRIPTION
## Summary

- Add pure-Rust X.509 certificate-chain verification over parsed `X509Data` chains.
- Require explicit DER trust anchors, replace untrusted embedded rollover roots, try every matching anchor through full path validation, and enforce validity, CA basic constraints, KeyUsage, path length, signatures, and maximum depth.
- Optionally authenticate embedded CRLs and reject certificates revoked at the selected verification time.
- Add real-fixture integration coverage for valid, untrusted, expired, tampered, depth-limited, malformed-CRL, and revoked paths.

## Security invariants

- Embedded self-signed certificates are not trusted unless byte-identical to a configured anchor.
- Embedded rollover roots are replaced only after they are authenticated as the issuer of the preceding certificate.
- Leaf certificates with KeyUsage must permit `digitalSignature` or `nonRepudiation`; issuer certificates with KeyUsage must permit `keyCertSign`.
- Certificate and CRL DER is parsed strictly with trailing-data rejection.
- CRL entries are applied only after issuer, signature, and validity checks.
- Unsupported certificate/CRL signature algorithms fail closed.

## Testing

- `cargo fmt -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo nextest run --test x509_chain_integration` (19/19)
- `cargo nextest run --workspace` (453/453)
- `cargo test --doc --workspace` (3/3)
- `cargo build --workspace`

Closes #62
