### PR TITLE
feat(xmldsig): expose signing public key info

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,11 +2,13 @@ version: 2
 updates:
   - package-ecosystem: cargo
     directory: /
+    rebase-strategy: auto
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
   - package-ecosystem: github-actions
     directory: /
+    rebase-strategy: auto
     schedule:
       interval: weekly
     ignore:

--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -4,6 +4,8 @@ git_release_enable = true
 changelog_update = true
 git_tag_name = "v{{ version }}"
 publish = false
+release_always = false
+release_commits = "^(feat|fix|perf|refactor|docs)(\\(.+\\))?:"
 
 [changelog]
 commit_parsers = [

--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -5,7 +5,7 @@ changelog_update = true
 git_tag_name = "v{{ version }}"
 publish = false
 release_always = false
-release_commits = "^(feat|fix|perf|refactor|docs)(\\(.+\\))?:"
+release_commits = "^(feat|fix|perf|refactor|docs)(\\([^()]+\\))?!?:"
 
 [changelog]
 commit_parsers = [

--- a/src/xmldsig/mod.rs
+++ b/src/xmldsig/mod.rs
@@ -32,8 +32,8 @@ pub use parse::{
 pub use sign::{
     ComputedReferenceDigest, EcdsaP256SigningKey, EcdsaP384SigningKey, KeyInfoWriteError,
     KeyInfoWriter, RsaSigningKey, SignContext, SigningDigestError, SigningError, SigningKey,
-    SigningKeyError, X509CertificateKeyInfoWriter, compute_reference_digest_values,
-    fill_reference_digest_values,
+    SigningKeyError, SigningPublicKeyInfo, X509CertificateKeyInfoWriter,
+    compute_reference_digest_values, fill_reference_digest_values,
 };
 pub use signature::{
     SignatureVerificationError, verify_ecdsa_signature_pem, verify_ecdsa_signature_spki,

--- a/src/xmldsig/sign.rs
+++ b/src/xmldsig/sign.rs
@@ -15,6 +15,7 @@ use rsa::RsaPrivateKey;
 use rsa::pkcs1v15::Signature as RsaPkcs1v15Signature;
 use rsa::pkcs1v15::SigningKey as RsaPkcs1v15SigningKey;
 use rsa::signature::{RandomizedSigner, SignatureEncoding, Signer};
+use rsa::traits::PublicKeyParts;
 use sha2::{Sha256, Sha384, Sha512};
 use std::collections::HashSet;
 use x509_parser::prelude::FromDer;
@@ -154,6 +155,40 @@ pub enum SigningKeyError {
     PublicKeyEncodingFailed,
 }
 
+/// Public key material corresponding to a private XMLDSig signing key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SigningPublicKeyInfo {
+    /// RSA public key with DER SubjectPublicKeyInfo and normalized parameters.
+    Rsa {
+        /// DER-encoded SubjectPublicKeyInfo bytes.
+        spki_der: Vec<u8>,
+        /// Unsigned big-endian RSA modulus (`n`), normalized without leading zeroes.
+        modulus: Vec<u8>,
+        /// Unsigned big-endian RSA public exponent (`e`), normalized without leading zeroes.
+        exponent: Vec<u8>,
+    },
+    /// EC public key with DER SubjectPublicKeyInfo and XMLDSig 1.1 KeyValue data.
+    Ec {
+        /// DER-encoded SubjectPublicKeyInfo bytes.
+        spki_der: Vec<u8>,
+        /// Bare named-curve OID, without the XMLDSig `urn:oid:` prefix.
+        curve_oid: &'static str,
+        /// Uncompressed SEC1 point (`0x04 || x || y`).
+        public_key: Vec<u8>,
+    },
+}
+
+impl SigningPublicKeyInfo {
+    /// Return DER-encoded SubjectPublicKeyInfo bytes for this public key.
+    #[must_use]
+    pub fn spki_der(&self) -> &[u8] {
+        match self {
+            Self::Rsa { spki_der, .. } | Self::Ec { spki_der, .. } => spki_der,
+        }
+    }
+}
+
 /// Private key abstraction used by [`SignContext`].
 pub trait SigningKey {
     /// Sign canonicalized `<SignedInfo>` bytes for the declared XMLDSig method.
@@ -163,8 +198,8 @@ pub trait SigningKey {
         canonical_signed_info: &[u8],
     ) -> Result<Vec<u8>, SigningKeyError>;
 
-    /// Return the public key corresponding to this signing key as SPKI DER.
-    fn public_key_spki_der(&self) -> Result<Vec<u8>, SigningKeyError>;
+    /// Return structured public key material corresponding to this signing key.
+    fn public_key_info(&self) -> Result<SigningPublicKeyInfo, SigningKeyError>;
 }
 
 /// Writes signing key metadata into a template `<KeyInfo>` element.
@@ -241,7 +276,8 @@ impl KeyInfoWriter for X509CertificateKeyInfoWriter {
         if !rest.is_empty() {
             return Err(KeyInfoWriteError::InvalidCertificateDer);
         }
-        if certificate.public_key().raw != signing_key.public_key_spki_der()? {
+        let signing_public_key = signing_key.public_key_info()?;
+        if certificate.public_key().raw != signing_public_key.spki_der() {
             return Err(KeyInfoWriteError::CertificateKeyMismatch);
         }
 
@@ -298,12 +334,17 @@ impl SigningKey for RsaSigningKey {
         }
     }
 
-    fn public_key_spki_der(&self) -> Result<Vec<u8>, SigningKeyError> {
-        self.key
-            .to_public_key()
+    fn public_key_info(&self) -> Result<SigningPublicKeyInfo, SigningKeyError> {
+        let public_key = self.key.to_public_key();
+        let spki_der = public_key
             .to_public_key_der()
             .map(|doc| doc.as_bytes().to_vec())
-            .map_err(|_| SigningKeyError::PublicKeyEncodingFailed)
+            .map_err(|_| SigningKeyError::PublicKeyEncodingFailed)?;
+        Ok(SigningPublicKeyInfo::Rsa {
+            spki_der,
+            modulus: public_key.n().to_be_bytes_trimmed_vartime().into_vec(),
+            exponent: public_key.e().to_be_bytes_trimmed_vartime().into_vec(),
+        })
     }
 }
 
@@ -355,12 +396,17 @@ impl SigningKey for EcdsaP256SigningKey {
         Ok(signature.to_bytes().to_vec())
     }
 
-    fn public_key_spki_der(&self) -> Result<Vec<u8>, SigningKeyError> {
-        self.key
-            .verifying_key()
+    fn public_key_info(&self) -> Result<SigningPublicKeyInfo, SigningKeyError> {
+        let verifying_key = self.key.verifying_key();
+        let spki_der = verifying_key
             .to_public_key_der()
             .map(|doc| doc.as_bytes().to_vec())
-            .map_err(|_| SigningKeyError::PublicKeyEncodingFailed)
+            .map_err(|_| SigningKeyError::PublicKeyEncodingFailed)?;
+        Ok(SigningPublicKeyInfo::Ec {
+            spki_der,
+            curve_oid: "1.2.840.10045.3.1.7",
+            public_key: verifying_key.to_sec1_point(false).as_bytes().to_vec(),
+        })
     }
 }
 
@@ -402,12 +448,17 @@ impl SigningKey for EcdsaP384SigningKey {
         Ok(signature.to_bytes().to_vec())
     }
 
-    fn public_key_spki_der(&self) -> Result<Vec<u8>, SigningKeyError> {
-        self.key
-            .verifying_key()
+    fn public_key_info(&self) -> Result<SigningPublicKeyInfo, SigningKeyError> {
+        let verifying_key = self.key.verifying_key();
+        let spki_der = verifying_key
             .to_public_key_der()
             .map(|doc| doc.as_bytes().to_vec())
-            .map_err(|_| SigningKeyError::PublicKeyEncodingFailed)
+            .map_err(|_| SigningKeyError::PublicKeyEncodingFailed)?;
+        Ok(SigningPublicKeyInfo::Ec {
+            spki_der,
+            curve_oid: "1.3.132.0.34",
+            public_key: verifying_key.to_sec1_point(false).as_bytes().to_vec(),
+        })
     }
 }
 

--- a/tests/signing_digest.rs
+++ b/tests/signing_digest.rs
@@ -6,9 +6,9 @@ use xml_sec::xmldsig::verify::process_all_references;
 use xml_sec::xmldsig::{
     DefaultKeyResolver, DigestAlgorithm, DsigStatus, EcdsaP256SigningKey, EcdsaP384SigningKey,
     KeyInfoWriter, ReferenceBuilder, RsaSigningKey, SignContext, SignatureAlgorithm,
-    SignatureBuilder, SigningDigestError, SigningError, Transform, X509CertificateKeyInfoWriter,
-    compute_reference_digest_values, fill_reference_digest_values, parse_key_info,
-    verify_signature_with_pem_key,
+    SignatureBuilder, SigningDigestError, SigningError, SigningKey, SigningKeyError,
+    SigningPublicKeyInfo, Transform, X509CertificateKeyInfoWriter, compute_reference_digest_values,
+    fill_reference_digest_values, parse_key_info, verify_signature_with_pem_key,
 };
 
 fn exclusive_c14n() -> C14nAlgorithm {
@@ -42,6 +42,147 @@ fn assert_reference_digests_verify(xml: &str) {
 
 fn read_fixture(path: &str) -> String {
     std::fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
+}
+
+#[test]
+fn rsa_signing_key_exposes_structured_public_key_info() {
+    // Public-key metadata must be available without reparsing the private key in
+    // each KeyInfo writer. RSA exposes SPKI plus normalized KeyValue fields.
+    let private_key =
+        RsaSigningKey::from_pkcs8_pem(&read_fixture("tests/fixtures/keys/rsa/rsa-2048-key.pem"))
+            .expect("RSA private key fixture must parse");
+    let public_key_info = private_key
+        .public_key_info()
+        .expect("RSA public-key info must encode");
+
+    match public_key_info {
+        SigningPublicKeyInfo::Rsa {
+            spki_der,
+            modulus,
+            exponent,
+        } => {
+            assert!(!spki_der.is_empty());
+            assert_eq!(modulus.len(), 256);
+            assert_eq!(exponent, [1, 0, 1]);
+        }
+        SigningPublicKeyInfo::Ec { .. } => panic!("RSA key must expose RSA public-key info"),
+        _ => panic!("RSA key must expose known public-key info"),
+    }
+}
+
+#[test]
+fn ecdsa_signing_keys_expose_curve_public_key_info() {
+    // ECDSA metadata includes the named curve and uncompressed SEC1 point needed
+    // by XMLDSig 1.1 ECKeyValue writers.
+    let p256_key = EcdsaP256SigningKey::from_pkcs8_pem(&read_fixture(
+        "tests/fixtures/keys/ec/ec-prime256v1-key.pem",
+    ))
+    .expect("P-256 private key fixture must parse");
+    let p384_key = EcdsaP384SigningKey::from_pkcs8_pem(&read_fixture(
+        "tests/fixtures/keys/ec/ec-prime384v1-key.pem",
+    ))
+    .expect("P-384 private key fixture must parse");
+
+    for (public_key_info, expected_oid, expected_len) in [
+        (
+            p256_key
+                .public_key_info()
+                .expect("P-256 public-key info must encode"),
+            "1.2.840.10045.3.1.7",
+            65,
+        ),
+        (
+            p384_key
+                .public_key_info()
+                .expect("P-384 public-key info must encode"),
+            "1.3.132.0.34",
+            97,
+        ),
+    ] {
+        match public_key_info {
+            SigningPublicKeyInfo::Ec {
+                spki_der,
+                curve_oid,
+                public_key,
+            } => {
+                assert!(!spki_der.is_empty());
+                assert_eq!(curve_oid, expected_oid);
+                assert_eq!(public_key.len(), expected_len);
+                assert_eq!(public_key[0], 0x04);
+            }
+            SigningPublicKeyInfo::Rsa { .. } => panic!("EC key must expose EC public-key info"),
+            _ => panic!("EC key must expose known public-key info"),
+        }
+    }
+}
+
+#[test]
+fn signing_keys_reject_unsupported_signature_algorithms() {
+    // The trait abstraction must fail closed when the caller asks a key to
+    // produce an incompatible XMLDSig SignatureMethod.
+    let rsa_key =
+        RsaSigningKey::from_pkcs8_pem(&read_fixture("tests/fixtures/keys/rsa/rsa-2048-key.pem"))
+            .expect("RSA private key fixture must parse");
+    let p256_key = EcdsaP256SigningKey::from_pkcs8_pem(&read_fixture(
+        "tests/fixtures/keys/ec/ec-prime256v1-key.pem",
+    ))
+    .expect("P-256 private key fixture must parse");
+    let p384_key = EcdsaP384SigningKey::from_pkcs8_pem(&read_fixture(
+        "tests/fixtures/keys/ec/ec-prime384v1-key.pem",
+    ))
+    .expect("P-384 private key fixture must parse");
+
+    for (result, expected_uri) in [
+        (
+            rsa_key.sign(SignatureAlgorithm::EcdsaP256Sha256, b"signed-info"),
+            SignatureAlgorithm::EcdsaP256Sha256.uri(),
+        ),
+        (
+            p256_key.sign(SignatureAlgorithm::RsaSha256, b"signed-info"),
+            SignatureAlgorithm::RsaSha256.uri(),
+        ),
+        (
+            p384_key.sign(SignatureAlgorithm::EcdsaP256Sha256, b"signed-info"),
+            SignatureAlgorithm::EcdsaP256Sha256.uri(),
+        ),
+    ] {
+        assert!(matches!(
+            result,
+            Err(SigningKeyError::UnsupportedAlgorithm { uri }) if uri == expected_uri
+        ));
+    }
+}
+
+#[test]
+fn x509_key_info_writer_uses_structured_public_key_info() {
+    struct PublicInfoFailingKey;
+
+    impl SigningKey for PublicInfoFailingKey {
+        fn sign(
+            &self,
+            _algorithm: SignatureAlgorithm,
+            _canonical_signed_info: &[u8],
+        ) -> Result<Vec<u8>, SigningKeyError> {
+            unreachable!("KeyInfo writer must not sign while serializing metadata");
+        }
+
+        fn public_key_info(&self) -> Result<SigningPublicKeyInfo, SigningKeyError> {
+            Err(SigningKeyError::PublicKeyEncodingFailed)
+        }
+    }
+
+    let certificate = X509CertificateKeyInfoWriter::from_pem(&read_fixture(
+        "tests/fixtures/keys/rsa/rsa-2048-cert.pem",
+    ))
+    .expect("RSA certificate fixture must parse");
+    let err = certificate
+        .write_key_info(&PublicInfoFailingKey)
+        .expect_err("writer must surface public-key info extraction failures");
+
+    assert!(matches!(
+        err,
+        xml_sec::xmldsig::KeyInfoWriteError::SigningKey(SigningKeyError::PublicKeyEncodingFailed)
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add structured `SigningPublicKeyInfo` for RSA and ECDSA signing keys.
- Wire X.509 KeyInfo output through the structured public-key API instead of raw SPKI-only extraction.
- Add regression coverage for RSA, P-256, P-384, unsupported algorithms, KeyInfo public-key extraction failures, and existing signing round-trips.
- Harden release automation after dependency PR base updates by disabling release-on-every-push and making Dependabot rebase behavior explicit.

## Release Automation Note

The release PR got stale after a dependency PR was updated by merging `main` into the Dependabot branch. That created a synthetic merge commit in the dependency PR branch; release-plz updated the open release PR metadata, but left a release commit/body that still showed the previous changelog section. This PR reduces that failure mode by:

- Running `release-plz release` only after the release PR is merged, not on every push to `main`.
- Requiring meaningful commit types before release-plz opens or updates a release PR.
- Making Dependabot's rebase strategy explicit so dependency branches are expected to stay linear.

## Validation

- `cargo fmt -- --check`
- `cargo check --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo nextest run --all-features` (540 passed)
- `cargo test --doc --all-features` (3 passed)

Closes #84
