### PR TITLE
feat(xmldsig): cover donor signing templates

### DIFF
--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -14,6 +14,7 @@ commit_parsers = [
     { message = "^style", skip = true },
     { message = "^build", skip = true },
     { message = "^docs\\(ci\\)", skip = true },
+    { message = "^docs\\(release\\)", skip = true },
     { message = "^Merge", skip = true },
     { message = "^docs", group = "Documentation" },
     { message = "^feat", group = "Added" },

--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -5,7 +5,7 @@ changelog_update = true
 git_tag_name = "v{{ version }}"
 publish = false
 release_always = false
-release_commits = "^(feat|fix|perf|refactor|docs)(\\([^()]+\\))?!?:"
+release_commits = "^(feat|fix|perf|refactor|docs)(\\((c14n|xmldsig|xmlenc|readme|test|ci|lint|review)\\))?!?:"
 
 [changelog]
 commit_parsers = [

--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -15,6 +15,7 @@ commit_parsers = [
     { message = "^build", skip = true },
     { message = "^docs\\(ci\\)", skip = true },
     { message = "^docs\\(release\\)", skip = true },
+    { message = "^fix\\(release\\)", skip = true },
     { message = "^Merge", skip = true },
     { message = "^docs", group = "Documentation" },
     { message = "^feat", group = "Added" },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(xmldsig)* write x509 signing key info
+- *(xmldsig)* cover donor signing templates
+
+### Fixed
+
+- *(xmldsig)* harden signing key info writer
+
 ## [0.1.8](https://github.com/structured-world/xml-sec/compare/v0.1.7...v0.1.8) - 2026-07-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - *(xmldsig)* write x509 signing key info
-- *(xmldsig)* cover donor signing templates
 
 ### Fixed
 

--- a/tests/fixtures/xmldsig/aleksey-xmldsig-01/enveloping-sha256-ecdsa-sha256.tmpl
+++ b/tests/fixtures/xmldsig/aleksey-xmldsig-01/enveloping-sha256-ecdsa-sha256.tmpl
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+  <SignedInfo>
+    <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />
+    <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256"/>
+    <Reference URI="#object">
+      <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+      <DigestValue></DigestValue>
+    </Reference>
+  </SignedInfo>
+  <SignatureValue>
+  </SignatureValue>
+  <KeyInfo>
+    <KeyName>TestKeyName-ec-prime256v1</KeyName>
+    <X509Data/>
+  </KeyInfo>
+  <Object Id="object">some text</Object>
+</Signature>

--- a/tests/fixtures/xmldsig/aleksey-xmldsig-01/enveloping-sha256-rsa-sha256.tmpl
+++ b/tests/fixtures/xmldsig/aleksey-xmldsig-01/enveloping-sha256-rsa-sha256.tmpl
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+  <SignedInfo>
+    <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />
+    <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+    <Reference URI="#object">
+      <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+      <DigestValue></DigestValue>
+    </Reference>
+  </SignedInfo>
+  <SignatureValue>
+  </SignatureValue>
+  <KeyInfo>
+    <KeyName>TestKeyName-rsa-2048</KeyName>
+    <X509Data/>
+  </KeyInfo>
+  <Object Id="object">some text</Object>
+</Signature>

--- a/tests/fixtures/xmldsig/aleksey-xmldsig-01/enveloping-sha384-ecdsa-sha384.tmpl
+++ b/tests/fixtures/xmldsig/aleksey-xmldsig-01/enveloping-sha384-ecdsa-sha384.tmpl
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+  <SignedInfo>
+    <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />
+    <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha384"/>
+    <Reference URI="#object">
+      <DigestMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#sha384"/>
+      <DigestValue></DigestValue>
+    </Reference>
+  </SignedInfo>
+  <SignatureValue>
+  </SignatureValue>
+  <KeyInfo>
+    <KeyName>TestKeyName-ec-prime521v1</KeyName>
+    <X509Data/>
+  </KeyInfo>
+  <Object Id="object">some text</Object>
+</Signature>

--- a/tests/fixtures/xmldsig/aleksey-xmldsig-01/enveloping-sha384-ecdsa-sha384.tmpl
+++ b/tests/fixtures/xmldsig/aleksey-xmldsig-01/enveloping-sha384-ecdsa-sha384.tmpl
@@ -11,7 +11,7 @@
   <SignatureValue>
   </SignatureValue>
   <KeyInfo>
-    <KeyName>TestKeyName-ec-prime521v1</KeyName>
+    <KeyName>TestKeyName-ec-prime384v1</KeyName>
     <X509Data/>
   </KeyInfo>
   <Object Id="object">some text</Object>

--- a/tests/fixtures/xmldsig/aleksey-xmldsig-01/enveloping-sha384-rsa-sha384.tmpl
+++ b/tests/fixtures/xmldsig/aleksey-xmldsig-01/enveloping-sha384-rsa-sha384.tmpl
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+  <SignedInfo>
+    <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />
+    <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha384"/>
+    <Reference URI="#object">
+      <DigestMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#sha384"/>
+      <DigestValue></DigestValue>
+    </Reference>
+  </SignedInfo>
+  <SignatureValue>
+  </SignatureValue>
+  <KeyInfo>
+    <KeyName>TestKeyName-rsa-4096</KeyName>
+    <X509Data/>
+  </KeyInfo>
+  <Object Id="object">some text</Object>
+</Signature>

--- a/tests/fixtures/xmldsig/aleksey-xmldsig-01/enveloping-sha512-rsa-sha512.tmpl
+++ b/tests/fixtures/xmldsig/aleksey-xmldsig-01/enveloping-sha512-rsa-sha512.tmpl
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+  <SignedInfo>
+    <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315" />
+    <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha512"/>
+    <Reference URI="#object">
+      <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"/>
+      <DigestValue></DigestValue>
+    </Reference>
+  </SignedInfo>
+  <SignatureValue>
+  </SignatureValue>
+  <KeyInfo>
+    <KeyName>TestKeyName-rsa-4096</KeyName>
+    <X509Data/>
+  </KeyInfo>
+  <Object Id="object">some text</Object>
+</Signature>

--- a/tests/fixtures_smoke.rs
+++ b/tests/fixtures_smoke.rs
@@ -176,8 +176,8 @@ fn fixture_file_count_matches_expected() {
     let mut count = 0;
     count_files_recursive(fixtures_dir(), &mut count);
     assert_eq!(
-        count, 82,
-        "expected 82 fixture files total (23 keys + 41 c14n + 17 donor xmldsig + 1 saml); \
+        count, 87,
+        "expected 87 fixture files total (23 keys + 41 c14n + 22 donor xmldsig + 1 saml); \
          if you added/removed files, update this count"
     );
 }

--- a/tests/signing_digest.rs
+++ b/tests/signing_digest.rs
@@ -44,6 +44,16 @@ fn read_fixture(path: &str) -> String {
     std::fs::read_to_string(path).unwrap_or_else(|err| panic!("failed to read {path}: {err}"))
 }
 
+fn assert_signed_template_verifies(signed: &str, public_key_path: &str) {
+    let public_key_pem = read_fixture(public_key_path);
+    let verify_result = verify_signature_with_pem_key(signed, &public_key_pem, true)
+        .expect("signed donor template must verify without pipeline errors");
+
+    assert_eq!(verify_result.status, DsigStatus::Valid);
+    assert!(signed.contains("<SignatureValue>"));
+    assert!(!signed.contains("<DigestValue></DigestValue>"));
+}
+
 #[test]
 fn rsa_signing_key_exposes_structured_public_key_info() {
     // Public-key metadata must be available without reparsing the private key in
@@ -666,4 +676,71 @@ fn signs_ecdsa_p384_template_and_verifies_round_trip() {
     assert_eq!(verify_result.status, DsigStatus::Valid);
     assert!(signed.contains("<SignatureValue>"));
     assert!(!signed.contains("<DigestValue></DigestValue>"));
+}
+
+#[test]
+fn signs_rsa_donor_templates_and_verifies_round_trip() {
+    // These are xmlsec1's supported enveloping signing templates. They exercise
+    // template parsing, object dereference, digest fill, SignedInfo c14n, and
+    // RSA PKCS#1 v1.5 signing without relying on our SignatureBuilder output.
+    for (template_path, private_key_path, public_key_path) in [
+        (
+            "tests/fixtures/xmldsig/aleksey-xmldsig-01/enveloping-sha256-rsa-sha256.tmpl",
+            "tests/fixtures/keys/rsa/rsa-2048-key.pem",
+            "tests/fixtures/keys/rsa/rsa-2048-pubkey.pem",
+        ),
+        (
+            "tests/fixtures/xmldsig/aleksey-xmldsig-01/enveloping-sha384-rsa-sha384.tmpl",
+            "tests/fixtures/keys/rsa/rsa-4096-key.pem",
+            "tests/fixtures/keys/rsa/rsa-4096-pubkey.pem",
+        ),
+        (
+            "tests/fixtures/xmldsig/aleksey-xmldsig-01/enveloping-sha512-rsa-sha512.tmpl",
+            "tests/fixtures/keys/rsa/rsa-4096-key.pem",
+            "tests/fixtures/keys/rsa/rsa-4096-pubkey.pem",
+        ),
+    ] {
+        let private_key = RsaSigningKey::from_pkcs8_pem(&read_fixture(private_key_path))
+            .expect("RSA private key fixture must parse");
+
+        let signed = SignContext::new(&private_key)
+            .sign_template(&read_fixture(template_path))
+            .expect("RSA donor template must sign");
+
+        assert_signed_template_verifies(&signed, public_key_path);
+    }
+}
+
+#[test]
+fn signs_ecdsa_donor_templates_and_verifies_round_trip() {
+    // The donor enveloped ECDSA templates include an XPath transform, which is
+    // intentionally blocked until XPath support lands. The enveloping templates
+    // cover the same ECDSA SignatureValue format without that blocked transform.
+    let p256_key = EcdsaP256SigningKey::from_pkcs8_pem(&read_fixture(
+        "tests/fixtures/keys/ec/ec-prime256v1-key.pem",
+    ))
+    .expect("P-256 private key fixture must parse");
+    let p256_signed = SignContext::new(&p256_key)
+        .sign_template(&read_fixture(
+            "tests/fixtures/xmldsig/aleksey-xmldsig-01/enveloping-sha256-ecdsa-sha256.tmpl",
+        ))
+        .expect("P-256 donor template must sign");
+    assert_signed_template_verifies(
+        &p256_signed,
+        "tests/fixtures/keys/ec/ec-prime256v1-pubkey.pem",
+    );
+
+    let p384_key = EcdsaP384SigningKey::from_pkcs8_pem(&read_fixture(
+        "tests/fixtures/keys/ec/ec-prime384v1-key.pem",
+    ))
+    .expect("P-384 private key fixture must parse");
+    let p384_signed = SignContext::new(&p384_key)
+        .sign_template(&read_fixture(
+            "tests/fixtures/xmldsig/aleksey-xmldsig-01/enveloping-sha384-ecdsa-sha384.tmpl",
+        ))
+        .expect("P-384 donor template must sign");
+    assert_signed_template_verifies(
+        &p384_signed,
+        "tests/fixtures/keys/ec/ec-prime384v1-pubkey.pem",
+    );
 }


### PR DESCRIPTION
## Summary
- Add supported xmlsec1 donor signing templates as fixtures.
- Sign RSA and ECDSA donor templates through SignContext and verify the generated XML with the existing verifier.
- Repair missing unreleased changelog entries and skip release-maintenance commits in release-plz output.

## Testing
- cargo fmt -- --check
- cargo nextest run
- cargo test --doc
- cargo clippy --all-targets -- -D warnings
- cargo build --all-features
- release-plz update --config .release-plz.toml --repo-url https://github.com/structured-world/xml-sec --allow-dirty (temp clone)

Closes #87