### PR TITLE
feat(xmlenc): add encryption pipeline

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/fixtures/xmlenc/aleksey-xmlenc-01/*.tmpl -text whitespace=-trailing-space,-space-before-tab

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ xmldsig = [            # XML Digital Signatures (sign + verify)
     "dep:subtle",
     "dep:x509-parser",
 ]
-xmlenc = [             # XML Encryption decryption
+xmlenc = [             # XML Encryption (encrypt + decrypt)
     "dep:aes",
     "dep:aes-gcm",
     "dep:aes-kw",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ keywords = ["xml", "xmldsig", "xmlenc", "c14n", "saml"]
 categories = ["cryptography", "web-programming", "authentication"]
 readme = "README.md"
 
+[[example]]
+name = "encrypt"
+required-features = ["xmlenc"]
+
 [dependencies]
 # XML parsing
 roxmltree = { version = "0.21", features = ["positions"] }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Pure Rust XML Security library. Drop-in replacement for libxmlsec1.
 
 - **C14N** — XML Canonicalization (inclusive + exclusive, W3C compliant)
 - **XMLDSig** — XML Digital Signatures (verify and signing pipelines, X.509 `KeyInfo`, and xmlsec1 CLI interoperability)
-- **XMLEnc** — XML Encryption decryption (direct, RSA-OAEP, and AES-KW keys)
+- **XMLEnc** — XML Encryption encrypt/decrypt pipelines (direct, RSA-OAEP, and AES-KW keys)
 - **X.509** — Certificate-based key extraction and validation
 
 ## Why?
@@ -46,12 +46,12 @@ Currently implemented (core paths):
 - ECDSA verification helpers for P-256/SHA-256 and P-384/SHA-384
 - RSA PKCS#1 v1.5 and ECDSA P-256/P-384 signing from PKCS#8 private keys
 - Opt-in X.509 certificate-chain validation with explicit trust anchors, validity checks, CA constraints, and CRLs
-- XMLEnc AES-128/256-CBC and AES-128/256-GCM decryption with direct keys,
-  RSA-OAEP key transport, and AES-128/256-KW key unwrapping
+- XMLEnc AES-128/256-CBC and AES-128/256-GCM encryption/decryption with direct
+  keys, RSA-OAEP key transport, AES-128/256-KW, multiple recipients, and
+  Element/Content document replacement
 
 Still in progress:
-- Broader XMLDSig donor/CLI interop coverage
-- XMLEnc encryption pipeline
+- Broader XMLDSig and XMLEnc donor/CLI interop coverage
 
 ## XMLDSig Usage
 
@@ -76,8 +76,48 @@ document; never continue an authentication flow after either outcome.
 
 ## XMLEnc Usage
 
-Enable the `xmlenc` feature, then decrypt either a standalone XML fragment or
-an `EncryptedData` value parsed once and retained by the caller:
+Enable the `xmlenc` feature. `EncryptedDataBuilder` can encrypt opaque bytes,
+one XML element, an XML content fragment, or a selected element in a complete
+document. This direct-key example creates a complete `EncryptedData` fragment
+and verifies it through the reciprocal decrypt path:
+
+```rust
+use xml_sec::xmlenc::{
+    DataEncryptionAlgorithm, DecryptedContent, EncryptedDataBuilder,
+    SymmetricKeyDecryptor, decrypt,
+};
+
+# fn example() -> Result<(), Box<dyn std::error::Error>> {
+let key = [0x42_u8; 16];
+let encrypted = EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm)
+    .direct_key(key)
+    .direct_key_name("application-content-key")
+    .encrypt_xml("<secret>value</secret>")?;
+
+assert_eq!(
+    decrypt(
+        &encrypted.encrypted_data_xml,
+        &SymmetricKeyDecryptor::new(key),
+    )?,
+    DecryptedContent::Xml("<secret>value</secret>".into()),
+);
+# Ok(())
+# }
+```
+
+For recipient transport, add one or more `EncryptionRecipient::rsa_oaep`
+entries with recipient public keys, or use `recipient_aes_kw` with a shared
+KEK. A fresh content key is generated from the operating-system RNG and wrapped
+once per recipient. XMLEnc 1.1 RSA-OAEP defaults to SHA-256/MGF1-SHA-256;
+legacy SHA-1 OAEP must be selected explicitly.
+
+`encrypt_document` selects the root or an element by `Id`, `ID`, or `id`, then
+replaces either the complete element or only its child content according to
+`EncryptedDataType`. The caller retains ownership of the resulting XML string.
+See `examples/encrypt.rs` for RSA-OAEP document encryption.
+
+To decrypt either a standalone XML fragment or an `EncryptedData` value parsed
+once and retained by the caller:
 
 ```rust
 use xml_sec::xmlenc::{
@@ -98,8 +138,10 @@ match plaintext {
 ```
 
 `PrivateKeyDecryptor` unwraps embedded RSA-OAEP `EncryptedKey` values and
-`KekDecryptor` unwraps AES-KW values. Cipher references and unauthenticated
-external resource loading are rejected; only inline `CipherValue` is accepted.
+`KekDecryptor` unwraps AES-KW values. RSA PKCS#1 v1.5 transport, CipherReference,
+and unauthenticated external resource loading are rejected; only inline
+`CipherValue` is accepted. Encryption inputs and recipient counts are bounded
+before allocation.
 
 Use `decrypt_document` to replace one typed `EncryptedData` in a caller-owned
 XML string. Pass its `Id` when the document contains multiple encrypted
@@ -119,7 +161,7 @@ Current MSRV: Rust 1.92.
 | [Canonical XML 1.1](https://www.w3.org/TR/xml-c14n11/) | Partially implemented |
 | [Exclusive C14N](https://www.w3.org/TR/xml-exc-c14n/) | Partially implemented |
 | [XMLDSig](https://www.w3.org/TR/xmldsig-core1/) | Partially implemented |
-| [XMLEnc](https://www.w3.org/TR/xmlenc-core1/) | Decryption subset implemented |
+| [XMLEnc](https://www.w3.org/TR/xmlenc-core1/) | AES-CBC/GCM encryption and decryption subset implemented |
 
 ## License
 

--- a/examples/encrypt.rs
+++ b/examples/encrypt.rs
@@ -1,0 +1,27 @@
+//! Encrypt an XML element for an RSA-OAEP recipient.
+//!
+//! Run with `cargo run --example encrypt --all-features`. The example uses a
+//! test public key solely to demonstrate the API; applications must resolve
+//! recipient keys from authenticated configuration or certificate metadata.
+
+use rsa::{RsaPublicKey, pkcs8::DecodePublicKey};
+use xml_sec::xmlenc::{DataEncryptionAlgorithm, EncryptedDataBuilder, EncryptionRecipient};
+
+const PUBLIC_KEY_PEM: &str = include_str!("../tests/fixtures/keys/rsa/rsa-2048-pubkey.pem");
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let public_key = RsaPublicKey::from_public_key_pem(PUBLIC_KEY_PEM)?;
+    let encrypted = EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes256Gcm)
+        .id("encrypted-assertion")
+        .add_recipient(
+            EncryptionRecipient::rsa_oaep(public_key)
+                .recipient("service-provider")
+                .key_name("service-provider-rsa"),
+        )
+        .encrypt_xml(
+            r#"<Assertion ID="assertion-1"><Subject>alice@example.com</Subject></Assertion>"#,
+        )?;
+
+    println!("{}", encrypted.encrypted_data_xml);
+    Ok(())
+}

--- a/scripts/import-donor-fixtures.sh
+++ b/scripts/import-donor-fixtures.sh
@@ -9,6 +9,12 @@ fixture_paths=("$@")
 if (( ${#fixture_paths[@]} == 0 )); then
   fixture_paths=(
     "xmldsig/aleksey-xmldsig-01/enveloping-rsa-x509chain.xml"
+    "xmlenc/aleksey-xmlenc-01/enc-aes128cbc-keyname.tmpl"
+    "xmlenc/aleksey-xmlenc-01/enc-aes128gcm-keyname.tmpl"
+    "xmlenc/aleksey-xmlenc-01/enc-aes256cbc-keyname.tmpl"
+    "xmlenc/aleksey-xmlenc-01/enc-aes256gcm-keyname.tmpl"
+    "xmlenc/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha1-params.tmpl"
+    "xmlenc/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_enc11_sha512_mgf1_sha512.tmpl"
   )
 fi
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! - **C14N** — XML Canonicalization (inclusive + exclusive)
 //! - **XMLDSig** — XML Digital Signatures (sign + verify)
-//! - **XMLEnc** — XML Encryption decryption
+//! - **XMLEnc** — XML Encryption (encrypt + decrypt)
 //! - **X.509** — Certificate-based key extraction
 //!
 //! ## Quick Start

--- a/src/xmlenc/decrypt.rs
+++ b/src/xmlenc/decrypt.rs
@@ -23,7 +23,8 @@ use super::parse::parse_encrypted_data_node;
 use super::types::XMLENC_NS;
 use super::{
     DataEncryptionAlgorithm, DecryptedContent, EncryptedData, EncryptedDataType, EncryptedKey,
-    KeyTransportAlgorithm, KeyWrapAlgorithm, XmlEncError, parse_encrypted_data,
+    KeyTransportAlgorithm, KeyWrapAlgorithm, XmlEncError, has_single_element_with_boundary_trivia,
+    parse_encrypted_data,
 };
 
 /// Supplies a content-encryption key for parsed XMLEnc data.
@@ -414,23 +415,7 @@ fn validate_plaintext_fragment(
     }
 
     if matches!(encrypted_type, Some(EncryptedDataType::Element)) {
-        let mut element_count = 0;
-        let valid_children = wrapper.children().all(|node| {
-            if node.is_element() {
-                element_count += 1;
-                true
-            } else if node.is_comment() {
-                true
-            } else if node.is_text() {
-                node.text().is_some_and(|text| {
-                    text.chars()
-                        .all(|character| matches!(character, ' ' | '\t' | '\n' | '\r'))
-                })
-            } else {
-                false
-            }
-        });
-        if !valid_children || element_count != 1 {
+        if !has_single_element_with_boundary_trivia(wrapper) {
             return Err(XmlEncError::InvalidStructure(
                 "Element plaintext must contain exactly one element".into(),
             ));

--- a/src/xmlenc/decrypt.rs
+++ b/src/xmlenc/decrypt.rs
@@ -1,5 +1,7 @@
 //! XMLEnc decryption entry point and key resolvers.
 
+use std::fmt;
+
 use aes::{
     Aes128, Aes256,
     cipher::{BlockModeDecrypt, KeyIvInit, block_padding::NoPadding},
@@ -11,9 +13,9 @@ use aes_gcm::{
 use aes_kw::{KwAes128, KwAes256};
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use cbc::Decryptor;
-use getrandom::{SysRng, rand_core::UnwrapErr};
+use getrandom::SysRng;
 use roxmltree::{Document, ParsingOptions};
-use rsa::{Oaep, RsaPrivateKey};
+use rsa::{Oaep, RsaPrivateKey, traits::PaddingScheme};
 use sha1::Sha1;
 use sha2::{Sha256, Sha384, Sha512};
 
@@ -47,9 +49,18 @@ pub struct DocumentDecryptionOptions<'a> {
 }
 
 /// Resolver for direct, pre-shared AES content keys.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SymmetricKeyDecryptor {
     key: Vec<u8>,
+}
+
+impl fmt::Debug for SymmetricKeyDecryptor {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SymmetricKeyDecryptor")
+            .field("key", &"[REDACTED]")
+            .finish()
+    }
 }
 
 impl SymmetricKeyDecryptor {
@@ -77,9 +88,18 @@ pub struct PrivateKeyDecryptor {
 }
 
 /// Resolver backed by a pre-shared AES key-encryption key (KEK).
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct KekDecryptor {
     kek: Vec<u8>,
+}
+
+impl fmt::Debug for KekDecryptor {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("KekDecryptor")
+            .field("kek", &"[REDACTED]")
+            .finish()
+    }
 }
 
 impl KekDecryptor {
@@ -172,42 +192,28 @@ impl PrivateKeyDecryptor {
         label: Vec<u8>,
         wrapped: &[u8],
     ) -> Result<Vec<u8>, XmlEncError> {
-        // Every private-key operation is blinded; UnwrapErr adapts the OS RNG
-        // to rsa's infallible CryptoRng contract.
+        // Passing SysRng through PaddingScheme keeps private-key blinding while
+        // preserving operating-system RNG failures as typed errors.
         match digest.unwrap_or("http://www.w3.org/2000/09/xmldsig#sha1") {
-            "http://www.w3.org/2000/09/xmldsig#sha1" => self
-                .key
-                .decrypt_blinded(
-                    &mut UnwrapErr(SysRng),
-                    Oaep::<Sha1>::new_with_label(label),
-                    wrapped,
-                )
+            "http://www.w3.org/2000/09/xmldsig#sha1" => Oaep::<Sha1>::new_with_label(label)
+                .decrypt(Some(&mut SysRng), &self.key, wrapped)
                 .map_err(rsa_error),
-            "http://www.w3.org/2001/04/xmlenc#sha256" => self
-                .key
-                .decrypt_blinded(
-                    &mut UnwrapErr(SysRng),
-                    Oaep::<Sha256, Sha1>::new_with_mgf_hash_and_label(label),
-                    wrapped,
-                )
-                .map_err(rsa_error),
+            "http://www.w3.org/2001/04/xmlenc#sha256" => {
+                Oaep::<Sha256, Sha1>::new_with_mgf_hash_and_label(label)
+                    .decrypt(Some(&mut SysRng), &self.key, wrapped)
+                    .map_err(rsa_error)
+            }
             "http://www.w3.org/2001/04/xmlenc#sha384"
-            | "http://www.w3.org/2001/04/xmldsig-more#sha384" => self
-                .key
-                .decrypt_blinded(
-                    &mut UnwrapErr(SysRng),
-                    Oaep::<Sha384, Sha1>::new_with_mgf_hash_and_label(label),
-                    wrapped,
-                )
-                .map_err(rsa_error),
-            "http://www.w3.org/2001/04/xmlenc#sha512" => self
-                .key
-                .decrypt_blinded(
-                    &mut UnwrapErr(SysRng),
-                    Oaep::<Sha512, Sha1>::new_with_mgf_hash_and_label(label),
-                    wrapped,
-                )
-                .map_err(rsa_error),
+            | "http://www.w3.org/2001/04/xmldsig-more#sha384" => {
+                Oaep::<Sha384, Sha1>::new_with_mgf_hash_and_label(label)
+                    .decrypt(Some(&mut SysRng), &self.key, wrapped)
+                    .map_err(rsa_error)
+            }
+            "http://www.w3.org/2001/04/xmlenc#sha512" => {
+                Oaep::<Sha512, Sha1>::new_with_mgf_hash_and_label(label)
+                    .decrypt(Some(&mut SysRng), &self.key, wrapped)
+                    .map_err(rsa_error)
+            }
             unsupported => Err(XmlEncError::UnsupportedAlgorithm(unsupported.to_owned())),
         }
     }
@@ -231,12 +237,8 @@ impl PrivateKeyDecryptor {
 
         macro_rules! decrypt_with {
             ($digest:ty, $mgf:ty) => {
-                self.key
-                    .decrypt_blinded(
-                        &mut UnwrapErr(SysRng),
-                        Oaep::<$digest, $mgf>::new_with_mgf_hash_and_label(label),
-                        wrapped,
-                    )
+                Oaep::<$digest, $mgf>::new_with_mgf_hash_and_label(label)
+                    .decrypt(Some(&mut SysRng), &self.key, wrapped)
                     .map_err(rsa_error)
             };
         }
@@ -271,7 +273,10 @@ impl PrivateKeyDecryptor {
 }
 
 fn rsa_error(error: rsa::Error) -> XmlEncError {
-    XmlEncError::Rsa(error.to_string())
+    match error {
+        rsa::Error::Rng => XmlEncError::Rng("RSA-OAEP blinding failed".into()),
+        error => XmlEncError::Rsa(error.to_string()),
+    }
 }
 
 fn invalid_kek_size(algorithm: KeyWrapAlgorithm, actual: usize) -> XmlEncError {

--- a/src/xmlenc/decrypt.rs
+++ b/src/xmlenc/decrypt.rs
@@ -414,12 +414,12 @@ fn validate_plaintext_fragment(
         ));
     }
 
-    if matches!(encrypted_type, Some(EncryptedDataType::Element)) {
-        if !has_single_element_with_boundary_trivia(wrapper) {
-            return Err(XmlEncError::InvalidStructure(
-                "Element plaintext must contain exactly one element".into(),
-            ));
-        }
+    if matches!(encrypted_type, Some(EncryptedDataType::Element))
+        && !has_single_element_with_boundary_trivia(wrapper)
+    {
+        return Err(XmlEncError::InvalidStructure(
+            "Element plaintext must contain exactly one element".into(),
+        ));
     }
     Ok(())
 }

--- a/src/xmlenc/encrypt.rs
+++ b/src/xmlenc/encrypt.rs
@@ -216,7 +216,7 @@ impl EncryptedDataBuilder {
             });
         }
         validate_metadata("EncryptedData Id", self.id.as_deref())?;
-        validate_metadata("direct KeyName", self.direct_key_name.as_deref())?;
+        validate_key_name("direct KeyName", self.direct_key_name.as_deref())?;
         for recipient in &self.recipients {
             match recipient {
                 EncryptionRecipient::RsaOaep {
@@ -226,7 +226,7 @@ impl EncryptedDataBuilder {
                     ..
                 } => {
                     validate_metadata("EncryptedKey Recipient", recipient.as_deref())?;
-                    validate_metadata("EncryptedKey KeyName", key_name.as_deref())?;
+                    validate_key_name("EncryptedKey KeyName", key_name.as_deref())?;
                     validate_metadata_len("OAEPparams", parameters.label.len())?;
                 }
                 EncryptionRecipient::AesKeyWrap {
@@ -235,7 +235,7 @@ impl EncryptedDataBuilder {
                     ..
                 } => {
                     validate_metadata("EncryptedKey Recipient", recipient.as_deref())?;
-                    validate_metadata("EncryptedKey KeyName", key_name.as_deref())?;
+                    validate_key_name("EncryptedKey KeyName", key_name.as_deref())?;
                 }
             }
         }
@@ -258,6 +258,15 @@ impl EncryptedDataBuilder {
 
 fn validate_metadata(field: &'static str, value: Option<&str>) -> Result<(), XmlEncError> {
     validate_metadata_len(field, value.map_or(0, str::len))
+}
+
+fn validate_key_name(field: &'static str, value: Option<&str>) -> Result<(), XmlEncError> {
+    if value.is_some_and(str::is_empty) {
+        return Err(XmlEncError::InvalidEncryptionConfig(format!(
+            "{field} must not be empty"
+        )));
+    }
+    validate_metadata(field, value)
 }
 
 fn validate_metadata_len(field: &'static str, actual: usize) -> Result<(), XmlEncError> {

--- a/src/xmlenc/encrypt.rs
+++ b/src/xmlenc/encrypt.rs
@@ -458,6 +458,9 @@ fn wrap_rsa_oaep(
     let mut rng = SysRng;
     macro_rules! encrypt_with {
         ($digest:ty, $mgf:ty) => {
+            // Call `PaddingScheme` directly: it accepts `TryCryptoRng`, so a
+            // `SysRng` failure returns `rsa::Error::Rng` for the mapping below
+            // instead of entering RSA's infallible `CryptoRng` convenience API.
             Oaep::<$digest, $mgf>::new_with_mgf_hash_and_label(parameters.label.clone()).encrypt(
                 &mut rng,
                 public_key,

--- a/src/xmlenc/encrypt.rs
+++ b/src/xmlenc/encrypt.rs
@@ -134,6 +134,7 @@ impl EncryptedDataBuilder {
         xml: &str,
         options: DocumentEncryptionOptions<'_>,
     ) -> Result<String, XmlEncError> {
+        validate_document_len(xml.len())?;
         let parsing_options = ParsingOptions {
             allow_dtd: options.allow_dtd,
             entity_resolver: None,
@@ -307,6 +308,16 @@ fn validate_plaintext_len(actual: usize) -> Result<(), XmlEncError> {
             actual,
         })
     }
+}
+
+fn validate_document_len(actual: usize) -> Result<(), XmlEncError> {
+    if actual > MAX_ENCRYPTION_DOCUMENT_LEN {
+        return Err(XmlEncError::DocumentTooLarge {
+            maximum: MAX_ENCRYPTION_DOCUMENT_LEN,
+            actual,
+        });
+    }
+    Ok(())
 }
 
 fn validate_content_key(algorithm: DataEncryptionAlgorithm, key: &[u8]) -> Result<(), XmlEncError> {

--- a/src/xmlenc/encrypt.rs
+++ b/src/xmlenc/encrypt.rs
@@ -1003,6 +1003,22 @@ mod tests {
     }
 
     #[test]
+    fn element_plaintext_enforces_replacement_node_contract() {
+        // Element ciphertext must be safe for the reciprocal document replacement:
+        // boundary whitespace/comments are harmless, but processing instructions are not.
+        let builder =
+            EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm).direct_key([0_u8; 16]);
+        builder
+            .encrypt_xml("\n<!--before--><secret/><!--after-->\n")
+            .expect("one element with boundary trivia must be accepted");
+
+        assert!(matches!(
+            builder.encrypt_xml("<?target value?><secret/>"),
+            Err(XmlEncError::InvalidStructure(_))
+        ));
+    }
+
+    #[test]
     fn empty_key_names_are_rejected_before_serialization() {
         // The reciprocal parser rejects empty KeyName elements, so encryption
         // must not emit output that its own decrypt pipeline cannot consume.

--- a/src/xmlenc/encrypt.rs
+++ b/src/xmlenc/encrypt.rs
@@ -947,6 +947,24 @@ mod tests {
     }
 
     #[test]
+    fn oversized_xml_is_rejected_before_parsing() {
+        // The input bound protects the parser and the Content wrapper
+        // allocation, so size must take precedence over malformed XML.
+        let oversized_malformed = format!(
+            "<child>{}</unclosed>",
+            "x".repeat(MAX_ENCRYPTION_PLAINTEXT_LEN)
+        );
+
+        assert!(matches!(
+            EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm)
+                .encryption_type(EncryptedDataType::Content)
+                .direct_key([0_u8; 16])
+                .encrypt_xml(&oversized_malformed),
+            Err(XmlEncError::PlaintextTooLarge { .. })
+        ));
+    }
+
+    #[test]
     fn debug_output_redacts_symmetric_key_material() {
         let direct_key = b"direct-key-secret".to_vec();
         let kek = b"key-wrap-secret!".to_vec();

--- a/src/xmlenc/encrypt.rs
+++ b/src/xmlenc/encrypt.rs
@@ -966,6 +966,28 @@ mod tests {
     }
 
     #[test]
+    fn empty_key_names_are_rejected_before_serialization() {
+        // The reciprocal parser rejects empty KeyName elements, so encryption
+        // must not emit output that its own decrypt pipeline cannot consume.
+        assert!(matches!(
+            EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm)
+                .direct_key([0_u8; 16])
+                .direct_key_name("")
+                .encrypt_binary(b"data"),
+            Err(XmlEncError::InvalidEncryptionConfig(_))
+        ));
+        assert!(matches!(
+            EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm)
+                .add_recipient(
+                    EncryptionRecipient::aes_key_wrap([0_u8; 16], KeyWrapAlgorithm::AesKw128)
+                        .key_name("")
+                )
+                .encrypt_binary(b"data"),
+            Err(XmlEncError::InvalidEncryptionConfig(_))
+        ));
+    }
+
+    #[test]
     fn debug_output_redacts_symmetric_key_material() {
         let direct_key = b"direct-key-secret".to_vec();
         let kek = b"key-wrap-secret!".to_vec();

--- a/src/xmlenc/encrypt.rs
+++ b/src/xmlenc/encrypt.rs
@@ -30,7 +30,7 @@ use super::types::{
 use super::{
     DataEncryptionAlgorithm, DocumentEncryptionOptions, EncryptedDataType, EncryptionRecipient,
     EncryptionResult, KeyWrapAlgorithm, OaepDigestAlgorithm, ReplacementMode, RsaOaepParameters,
-    XmlEncError,
+    XmlEncError, has_single_element_with_boundary_trivia,
 };
 
 const XML_WHITESPACE: &[char] = &[' ', '\t', '\n', '\r'];
@@ -675,7 +675,7 @@ fn validate_xml_plaintext(
     match encrypted_type {
         EncryptedDataType::Element => {
             let document = Document::parse(xml)?;
-            if document.root().children().filter(Node::is_element).count() != 1 {
+            if !has_single_element_with_boundary_trivia(document.root()) {
                 return Err(XmlEncError::InvalidStructure(
                     "Element plaintext must contain exactly one element".into(),
                 ));

--- a/src/xmlenc/encrypt.rs
+++ b/src/xmlenc/encrypt.rs
@@ -708,6 +708,8 @@ fn element_content_boundaries(source: &str) -> Result<ContentBoundaries, XmlEncE
             start_tag_end: tag_end,
         });
     }
+    // `Node::range()` ends at this element's closing tag, so its `</` marker is
+    // necessarily the final one even when child text or CDATA contains `</`.
     let closing_start = source
         .rfind("</")
         .ok_or_else(|| XmlEncError::InvalidStructure("source element has no closing tag".into()))?;

--- a/src/xmlenc/encrypt.rs
+++ b/src/xmlenc/encrypt.rs
@@ -258,7 +258,26 @@ impl EncryptedDataBuilder {
 }
 
 fn validate_metadata(field: &'static str, value: Option<&str>) -> Result<(), XmlEncError> {
+    if value.is_some_and(|value| !value.chars().all(is_xml_1_0_character)) {
+        return Err(XmlEncError::InvalidEncryptionConfig(format!(
+            "{field} contains a character forbidden by XML 1.0"
+        )));
+    }
     validate_metadata_len(field, value.map_or(0, str::len))
+}
+
+fn is_xml_1_0_character(character: char) -> bool {
+    // XML 1.0 Fifth Edition, production [2]. Rust `char` cannot represent the
+    // surrogate range between D7FF and E000, but the split keeps that exclusion explicit.
+    matches!(
+        character,
+        '\u{9}'
+            | '\u{A}'
+            | '\u{D}'
+            | '\u{20}'..='\u{D7FF}'
+            | '\u{E000}'..='\u{FFFD}'
+            | '\u{10000}'..='\u{10FFFF}'
+    )
 }
 
 fn validate_key_name(field: &'static str, value: Option<&str>) -> Result<(), XmlEncError> {

--- a/src/xmlenc/encrypt.rs
+++ b/src/xmlenc/encrypt.rs
@@ -24,8 +24,8 @@ use sha1::Sha1;
 use sha2::{Sha256, Sha384, Sha512};
 
 use super::types::{
-    MAX_ENCRYPTION_METADATA_LEN, MAX_ENCRYPTION_PLAINTEXT_LEN, MAX_ENCRYPTION_RECIPIENTS,
-    XMLDSIG_NS, XMLENC_NS, XMLENC11_NS,
+    MAX_ENCRYPTION_DOCUMENT_LEN, MAX_ENCRYPTION_METADATA_LEN, MAX_ENCRYPTION_PLAINTEXT_LEN,
+    MAX_ENCRYPTION_RECIPIENTS, XMLDSIG_NS, XMLENC_NS, XMLENC11_NS,
 };
 use super::{
     DataEncryptionAlgorithm, DocumentEncryptionOptions, EncryptedDataType, EncryptionRecipient,
@@ -971,6 +971,23 @@ mod tests {
                 .direct_key([0_u8; 16])
                 .encrypt_xml(&oversized_malformed),
             Err(XmlEncError::PlaintextTooLarge { .. })
+        ));
+    }
+
+    #[test]
+    fn oversized_document_is_rejected_before_parsing() {
+        // The document API has a separate parser-input bound because the
+        // selected plaintext may be much smaller than its enclosing document.
+        let oversized_malformed = format!(
+            "<root>{}</unclosed>",
+            "x".repeat(MAX_ENCRYPTION_DOCUMENT_LEN)
+        );
+
+        assert!(matches!(
+            EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm)
+                .direct_key([0_u8; 16])
+                .encrypt_document(&oversized_malformed, DocumentEncryptionOptions::default()),
+            Err(XmlEncError::DocumentTooLarge { .. })
         ));
     }
 

--- a/src/xmlenc/encrypt.rs
+++ b/src/xmlenc/encrypt.rs
@@ -118,6 +118,7 @@ impl EncryptedDataBuilder {
 
     /// Encrypt one complete XML element or an XML content fragment.
     pub fn encrypt_xml(&self, xml: &str) -> Result<EncryptionResult, XmlEncError> {
+        validate_plaintext_len(xml.len())?;
         validate_xml_plaintext(xml, &self.encrypted_type)?;
         self.encrypt_payload(xml.as_bytes(), Some(self.encrypted_type.clone()))
     }

--- a/src/xmlenc/encrypt.rs
+++ b/src/xmlenc/encrypt.rs
@@ -1,0 +1,959 @@
+//! XMLEnc content encryption, key wrapping, and XML generation.
+
+use std::fmt;
+
+use aes::{
+    Aes128, Aes256,
+    cipher::{BlockModeEncrypt, KeyIvInit, block_padding::NoPadding},
+};
+use aes_gcm::{
+    Aes128Gcm, Aes256Gcm, Nonce,
+    aead::{AeadInOut, KeyInit},
+};
+use aes_kw::{KwAes128, KwAes256};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use cbc::Encryptor;
+use getrandom::{SysRng, rand_core::TryRng};
+use quick_xml::{
+    Writer,
+    events::{BytesEnd, BytesStart, BytesText, Event},
+};
+use roxmltree::{Document, Node, ParsingOptions};
+use rsa::{Oaep, RsaPublicKey, traits::PaddingScheme};
+use sha1::Sha1;
+use sha2::{Sha256, Sha384, Sha512};
+
+use super::types::{
+    MAX_ENCRYPTION_METADATA_LEN, MAX_ENCRYPTION_PLAINTEXT_LEN, MAX_ENCRYPTION_RECIPIENTS,
+    XMLDSIG_NS, XMLENC_NS, XMLENC11_NS,
+};
+use super::{
+    DataEncryptionAlgorithm, DocumentEncryptionOptions, EncryptedDataType, EncryptionRecipient,
+    EncryptionResult, KeyWrapAlgorithm, OaepDigestAlgorithm, ReplacementMode, RsaOaepParameters,
+    XmlEncError,
+};
+
+const XML_WHITESPACE: &[char] = &[' ', '\t', '\n', '\r'];
+
+/// Builder for complete `EncryptedData` fragments and document replacement.
+#[derive(Clone)]
+pub struct EncryptedDataBuilder {
+    algorithm: DataEncryptionAlgorithm,
+    encrypted_type: EncryptedDataType,
+    id: Option<String>,
+    direct_key: Option<Vec<u8>>,
+    direct_key_name: Option<String>,
+    recipients: Vec<EncryptionRecipient>,
+}
+
+impl fmt::Debug for EncryptedDataBuilder {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("EncryptedDataBuilder")
+            .field("algorithm", &self.algorithm)
+            .field("encrypted_type", &self.encrypted_type)
+            .field("id", &self.id)
+            .field(
+                "direct_key",
+                &self.direct_key.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field("direct_key_name", &self.direct_key_name)
+            .field("recipients", &self.recipients)
+            .finish()
+    }
+}
+
+impl EncryptedDataBuilder {
+    /// Create a builder for a content-encryption algorithm.
+    pub fn new(algorithm: DataEncryptionAlgorithm) -> Self {
+        Self {
+            algorithm,
+            encrypted_type: EncryptedDataType::Element,
+            id: None,
+            direct_key: None,
+            direct_key_name: None,
+            recipients: Vec::new(),
+        }
+    }
+
+    /// Set whether XML encryption covers one element or its child content.
+    pub fn encryption_type(mut self, encrypted_type: EncryptedDataType) -> Self {
+        self.encrypted_type = encrypted_type;
+        self
+    }
+
+    /// Set the generated `EncryptedData` identifier.
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.id = Some(id.into());
+        self
+    }
+
+    /// Use a caller-managed content key instead of generating and wrapping one.
+    pub fn direct_key(mut self, key: impl Into<Vec<u8>>) -> Self {
+        self.direct_key = Some(key.into());
+        self
+    }
+
+    /// Emit a direct `KeyName` hint for a caller-managed content key.
+    pub fn direct_key_name(mut self, key_name: impl Into<String>) -> Self {
+        self.direct_key_name = Some(key_name.into());
+        self
+    }
+
+    /// Add one independently wrapped recipient of the generated content key.
+    pub fn add_recipient(mut self, recipient: EncryptionRecipient) -> Self {
+        self.recipients.push(recipient);
+        self
+    }
+
+    /// Add an RSA-OAEP recipient using secure XMLEnc 1.1 defaults.
+    pub fn recipient_rsa_oaep(self, public_key: RsaPublicKey) -> Self {
+        self.add_recipient(EncryptionRecipient::rsa_oaep(public_key))
+    }
+
+    /// Add an AES Key Wrap recipient.
+    pub fn recipient_aes_kw(self, kek: impl Into<Vec<u8>>, algorithm: KeyWrapAlgorithm) -> Self {
+        self.add_recipient(EncryptionRecipient::aes_key_wrap(kek, algorithm))
+    }
+
+    /// Encrypt one complete XML element or an XML content fragment.
+    pub fn encrypt_xml(&self, xml: &str) -> Result<EncryptionResult, XmlEncError> {
+        validate_xml_plaintext(xml, &self.encrypted_type)?;
+        self.encrypt_payload(xml.as_bytes(), Some(self.encrypted_type.clone()))
+    }
+
+    /// Encrypt opaque bytes without an XML `Type` attribute.
+    pub fn encrypt_binary(&self, data: &[u8]) -> Result<EncryptionResult, XmlEncError> {
+        self.encrypt_payload(data, None)
+    }
+
+    /// Encrypt and replace the document root or one element selected by XML ID.
+    pub fn encrypt_document(
+        &self,
+        xml: &str,
+        options: DocumentEncryptionOptions<'_>,
+    ) -> Result<String, XmlEncError> {
+        let parsing_options = ParsingOptions {
+            allow_dtd: options.allow_dtd,
+            entity_resolver: None,
+            ..ParsingOptions::default()
+        };
+        let document = Document::parse_with_options(xml, parsing_options)?;
+        let selected = select_encryption_target(&document, options.element_id)?;
+        let range = selected.range();
+        let source = &xml[range.clone()];
+
+        match self.encrypted_type {
+            EncryptedDataType::Element => {
+                let result =
+                    self.encrypt_payload(source.as_bytes(), Some(EncryptedDataType::Element))?;
+                Ok(replace_range(xml, range, &result.encrypted_data_xml))
+            }
+            EncryptedDataType::Content => {
+                let boundaries = element_content_boundaries(source)?;
+                let plaintext = &source[boundaries.content.clone()];
+                let result =
+                    self.encrypt_payload(plaintext.as_bytes(), Some(EncryptedDataType::Content))?;
+                replace_element_content(xml, range, source, boundaries, &result.encrypted_data_xml)
+            }
+            EncryptedDataType::Other(_) => Err(XmlEncError::InvalidEncryptionConfig(
+                "document encryption requires Element or Content Type".into(),
+            )),
+        }
+    }
+
+    fn encrypt_payload(
+        &self,
+        plaintext: &[u8],
+        encrypted_type: Option<EncryptedDataType>,
+    ) -> Result<EncryptionResult, XmlEncError> {
+        validate_plaintext_len(plaintext.len())?;
+        self.validate_configuration()?;
+
+        let content_key = if let Some(key) = &self.direct_key {
+            validate_content_key(self.algorithm, key)?;
+            key.clone()
+        } else {
+            random_bytes(self.algorithm.key_len())?
+        };
+        let ciphertext = encrypt_content(self.algorithm, &content_key, plaintext)?;
+        let encrypted_keys = self
+            .recipients
+            .iter()
+            .map(|recipient| wrap_content_key(recipient, &content_key))
+            .collect::<Result<Vec<_>, _>>()?;
+        let encrypted_data_xml = render_encrypted_data(
+            self.algorithm,
+            encrypted_type.as_ref(),
+            self.id.as_deref(),
+            self.direct_key_name.as_deref(),
+            &encrypted_keys,
+            &ciphertext,
+        )?;
+        let replacement = match encrypted_type {
+            Some(EncryptedDataType::Content) => ReplacementMode::ReplaceContent,
+            Some(EncryptedDataType::Element | EncryptedDataType::Other(_)) | None => {
+                ReplacementMode::ReplaceElement
+            }
+        };
+        Ok(EncryptionResult {
+            encrypted_data_xml,
+            replacement,
+        })
+    }
+
+    fn validate_configuration(&self) -> Result<(), XmlEncError> {
+        if matches!(self.encrypted_type, EncryptedDataType::Other(_)) {
+            return Err(XmlEncError::InvalidEncryptionConfig(
+                "Other Type hints are not valid for XML encryption".into(),
+            ));
+        }
+        if self.recipients.len() > MAX_ENCRYPTION_RECIPIENTS {
+            return Err(XmlEncError::TooManyRecipients {
+                maximum: MAX_ENCRYPTION_RECIPIENTS,
+                actual: self.recipients.len(),
+            });
+        }
+        validate_metadata("EncryptedData Id", self.id.as_deref())?;
+        validate_metadata("direct KeyName", self.direct_key_name.as_deref())?;
+        for recipient in &self.recipients {
+            match recipient {
+                EncryptionRecipient::RsaOaep {
+                    parameters,
+                    recipient,
+                    key_name,
+                    ..
+                } => {
+                    validate_metadata("EncryptedKey Recipient", recipient.as_deref())?;
+                    validate_metadata("EncryptedKey KeyName", key_name.as_deref())?;
+                    validate_metadata_len("OAEPparams", parameters.label.len())?;
+                }
+                EncryptionRecipient::AesKeyWrap {
+                    recipient,
+                    key_name,
+                    ..
+                } => {
+                    validate_metadata("EncryptedKey Recipient", recipient.as_deref())?;
+                    validate_metadata("EncryptedKey KeyName", key_name.as_deref())?;
+                }
+            }
+        }
+        match (self.direct_key.is_some(), self.recipients.is_empty()) {
+            (false, true) => Err(XmlEncError::InvalidEncryptionConfig(
+                "configure a direct content key or at least one wrapped recipient".into(),
+            )),
+            (true, false) => Err(XmlEncError::InvalidEncryptionConfig(
+                "a direct content key cannot be combined with wrapped recipients".into(),
+            )),
+            _ if self.direct_key_name.is_some() && self.direct_key.is_none() => {
+                Err(XmlEncError::InvalidEncryptionConfig(
+                    "direct KeyName requires a direct content key".into(),
+                ))
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+fn validate_metadata(field: &'static str, value: Option<&str>) -> Result<(), XmlEncError> {
+    validate_metadata_len(field, value.map_or(0, str::len))
+}
+
+fn validate_metadata_len(field: &'static str, actual: usize) -> Result<(), XmlEncError> {
+    if actual <= MAX_ENCRYPTION_METADATA_LEN {
+        Ok(())
+    } else {
+        Err(XmlEncError::EncryptionMetadataTooLarge {
+            field,
+            maximum: MAX_ENCRYPTION_METADATA_LEN,
+            actual,
+        })
+    }
+}
+
+#[derive(Debug)]
+struct WrappedKey {
+    algorithm_uri: &'static str,
+    oaep: Option<RsaOaepParameters>,
+    recipient: Option<String>,
+    key_name: Option<String>,
+    ciphertext: Vec<u8>,
+}
+
+#[derive(Debug)]
+struct ContentBoundaries {
+    content: std::ops::Range<usize>,
+    self_closing: bool,
+    qualified_name: String,
+    start_tag_end: usize,
+}
+
+fn validate_plaintext_len(actual: usize) -> Result<(), XmlEncError> {
+    if actual <= MAX_ENCRYPTION_PLAINTEXT_LEN {
+        Ok(())
+    } else {
+        Err(XmlEncError::PlaintextTooLarge {
+            maximum: MAX_ENCRYPTION_PLAINTEXT_LEN,
+            actual,
+        })
+    }
+}
+
+fn validate_content_key(algorithm: DataEncryptionAlgorithm, key: &[u8]) -> Result<(), XmlEncError> {
+    if key.len() == algorithm.key_len() {
+        Ok(())
+    } else {
+        Err(XmlEncError::InvalidKeySize {
+            algorithm,
+            expected: algorithm.key_len(),
+            actual: key.len(),
+        })
+    }
+}
+
+fn random_bytes(len: usize) -> Result<Vec<u8>, XmlEncError> {
+    let mut bytes = vec![0_u8; len];
+    SysRng
+        .try_fill_bytes(&mut bytes)
+        .map_err(|error| XmlEncError::Rng(error.to_string()))?;
+    Ok(bytes)
+}
+
+fn encrypt_content(
+    algorithm: DataEncryptionAlgorithm,
+    key: &[u8],
+    plaintext: &[u8],
+) -> Result<Vec<u8>, XmlEncError> {
+    validate_content_key(algorithm, key)?;
+    match algorithm {
+        DataEncryptionAlgorithm::Aes128Cbc => encrypt_cbc::<Aes128>(key, plaintext),
+        DataEncryptionAlgorithm::Aes256Cbc => encrypt_cbc::<Aes256>(key, plaintext),
+        DataEncryptionAlgorithm::Aes128Gcm => encrypt_gcm::<Aes128Gcm>(key, plaintext),
+        DataEncryptionAlgorithm::Aes256Gcm => encrypt_gcm::<Aes256Gcm>(key, plaintext),
+    }
+}
+
+fn encrypt_cbc<C>(key: &[u8], plaintext: &[u8]) -> Result<Vec<u8>, XmlEncError>
+where
+    C: aes::cipher::BlockCipherEncrypt + aes::cipher::KeyInit,
+{
+    const BLOCK: usize = 16;
+    let iv = random_bytes(BLOCK)?;
+    let pad_len = BLOCK - (plaintext.len() % BLOCK);
+    let mut padded = Vec::with_capacity(plaintext.len() + pad_len);
+    padded.extend_from_slice(plaintext);
+    if pad_len > 1 {
+        padded.extend_from_slice(&random_bytes(pad_len - 1)?);
+    }
+    padded.push(pad_len as u8);
+    let padded_len = padded.len();
+    Encryptor::<C>::new_from_slices(key, &iv)
+        .map_err(|_| XmlEncError::InvalidKeySize {
+            algorithm: if key.len() == 16 {
+                DataEncryptionAlgorithm::Aes128Cbc
+            } else {
+                DataEncryptionAlgorithm::Aes256Cbc
+            },
+            expected: key.len(),
+            actual: key.len(),
+        })?
+        .encrypt_padded::<NoPadding>(&mut padded, padded_len)
+        .map_err(|error| XmlEncError::XmlSerialize(error.to_string()))?;
+    let mut output = Vec::with_capacity(BLOCK + padded.len());
+    output.extend_from_slice(&iv);
+    output.extend_from_slice(&padded);
+    Ok(output)
+}
+
+fn encrypt_gcm<C>(key: &[u8], plaintext: &[u8]) -> Result<Vec<u8>, XmlEncError>
+where
+    C: AeadInOut + KeyInit,
+{
+    const NONCE_LEN: usize = 12;
+    let nonce = random_bytes(NONCE_LEN)?;
+    let cipher = C::new_from_slice(key).map_err(|_| XmlEncError::InvalidKeySize {
+        algorithm: if key.len() == 16 {
+            DataEncryptionAlgorithm::Aes128Gcm
+        } else {
+            DataEncryptionAlgorithm::Aes256Gcm
+        },
+        expected: key.len(),
+        actual: key.len(),
+    })?;
+    let mut encrypted = plaintext.to_vec();
+    let nonce_value = Nonce::try_from(nonce.as_slice())
+        .map_err(|error| XmlEncError::XmlSerialize(error.to_string()))?;
+    cipher
+        .encrypt_in_place(&nonce_value, b"", &mut encrypted)
+        .map_err(|_| XmlEncError::AeadAuthenticationFailed)?;
+    let mut output = Vec::with_capacity(NONCE_LEN + encrypted.len());
+    output.extend_from_slice(&nonce);
+    output.extend_from_slice(&encrypted);
+    Ok(output)
+}
+
+fn wrap_content_key(
+    recipient: &EncryptionRecipient,
+    content_key: &[u8],
+) -> Result<WrappedKey, XmlEncError> {
+    match recipient {
+        EncryptionRecipient::RsaOaep {
+            public_key,
+            parameters,
+            recipient,
+            key_name,
+        } => Ok(WrappedKey {
+            algorithm_uri: parameters.algorithm.uri(),
+            oaep: Some(parameters.clone()),
+            recipient: recipient.clone(),
+            key_name: key_name.clone(),
+            ciphertext: wrap_rsa_oaep(public_key, parameters, content_key)?,
+        }),
+        EncryptionRecipient::AesKeyWrap {
+            kek,
+            algorithm,
+            recipient,
+            key_name,
+        } => {
+            if kek.len() != algorithm.key_len() {
+                return Err(XmlEncError::InvalidKekSize {
+                    algorithm: *algorithm,
+                    expected: algorithm.key_len(),
+                    actual: kek.len(),
+                });
+            }
+            let mut output = vec![0_u8; content_key.len() + 8];
+            let wrapped = match algorithm {
+                KeyWrapAlgorithm::AesKw128 => KwAes128::new_from_slice(kek)
+                    .map_err(|_| invalid_kek_size(*algorithm, kek.len()))?
+                    .wrap_key(content_key, &mut output),
+                KeyWrapAlgorithm::AesKw256 => KwAes256::new_from_slice(kek)
+                    .map_err(|_| invalid_kek_size(*algorithm, kek.len()))?
+                    .wrap_key(content_key, &mut output),
+            }
+            .map_err(|_| XmlEncError::KeyWrapIntegrity)?;
+            Ok(WrappedKey {
+                algorithm_uri: algorithm.uri(),
+                oaep: None,
+                recipient: recipient.clone(),
+                key_name: key_name.clone(),
+                ciphertext: wrapped.to_vec(),
+            })
+        }
+    }
+}
+
+fn wrap_rsa_oaep(
+    public_key: &RsaPublicKey,
+    parameters: &RsaOaepParameters,
+    content_key: &[u8],
+) -> Result<Vec<u8>, XmlEncError> {
+    if parameters.algorithm == super::KeyTransportAlgorithm::RsaOaepMgf1p
+        && parameters.mgf_digest != OaepDigestAlgorithm::Sha1
+    {
+        return Err(XmlEncError::InvalidEncryptionConfig(
+            "legacy rsa-oaep-mgf1p requires MGF1-SHA1".into(),
+        ));
+    }
+    let mut rng = SysRng;
+    macro_rules! encrypt_with {
+        ($digest:ty, $mgf:ty) => {
+            Oaep::<$digest, $mgf>::new_with_mgf_hash_and_label(parameters.label.clone()).encrypt(
+                &mut rng,
+                public_key,
+                content_key,
+            )
+        };
+    }
+    let result = match (parameters.digest, parameters.mgf_digest) {
+        (OaepDigestAlgorithm::Sha1, OaepDigestAlgorithm::Sha1) => {
+            encrypt_with!(Sha1, Sha1)
+        }
+        (OaepDigestAlgorithm::Sha1, OaepDigestAlgorithm::Sha256) => {
+            encrypt_with!(Sha1, Sha256)
+        }
+        (OaepDigestAlgorithm::Sha1, OaepDigestAlgorithm::Sha384) => {
+            encrypt_with!(Sha1, Sha384)
+        }
+        (OaepDigestAlgorithm::Sha1, OaepDigestAlgorithm::Sha512) => {
+            encrypt_with!(Sha1, Sha512)
+        }
+        (OaepDigestAlgorithm::Sha256, OaepDigestAlgorithm::Sha1) => {
+            encrypt_with!(Sha256, Sha1)
+        }
+        (OaepDigestAlgorithm::Sha256, OaepDigestAlgorithm::Sha256) => {
+            encrypt_with!(Sha256, Sha256)
+        }
+        (OaepDigestAlgorithm::Sha256, OaepDigestAlgorithm::Sha384) => {
+            encrypt_with!(Sha256, Sha384)
+        }
+        (OaepDigestAlgorithm::Sha256, OaepDigestAlgorithm::Sha512) => {
+            encrypt_with!(Sha256, Sha512)
+        }
+        (OaepDigestAlgorithm::Sha384, OaepDigestAlgorithm::Sha1) => {
+            encrypt_with!(Sha384, Sha1)
+        }
+        (OaepDigestAlgorithm::Sha384, OaepDigestAlgorithm::Sha256) => {
+            encrypt_with!(Sha384, Sha256)
+        }
+        (OaepDigestAlgorithm::Sha384, OaepDigestAlgorithm::Sha384) => {
+            encrypt_with!(Sha384, Sha384)
+        }
+        (OaepDigestAlgorithm::Sha384, OaepDigestAlgorithm::Sha512) => {
+            encrypt_with!(Sha384, Sha512)
+        }
+        (OaepDigestAlgorithm::Sha512, OaepDigestAlgorithm::Sha1) => {
+            encrypt_with!(Sha512, Sha1)
+        }
+        (OaepDigestAlgorithm::Sha512, OaepDigestAlgorithm::Sha256) => {
+            encrypt_with!(Sha512, Sha256)
+        }
+        (OaepDigestAlgorithm::Sha512, OaepDigestAlgorithm::Sha384) => {
+            encrypt_with!(Sha512, Sha384)
+        }
+        (OaepDigestAlgorithm::Sha512, OaepDigestAlgorithm::Sha512) => {
+            encrypt_with!(Sha512, Sha512)
+        }
+    };
+    result.map_err(|error| match error {
+        rsa::Error::Rng => XmlEncError::Rng("RSA-OAEP random generation failed".into()),
+        error => XmlEncError::RsaEncrypt(error.to_string()),
+    })
+}
+
+fn invalid_kek_size(algorithm: KeyWrapAlgorithm, actual: usize) -> XmlEncError {
+    XmlEncError::InvalidKekSize {
+        algorithm,
+        expected: algorithm.key_len(),
+        actual,
+    }
+}
+
+fn render_encrypted_data(
+    algorithm: DataEncryptionAlgorithm,
+    encrypted_type: Option<&EncryptedDataType>,
+    id: Option<&str>,
+    direct_key_name: Option<&str>,
+    encrypted_keys: &[WrappedKey],
+    ciphertext: &[u8],
+) -> Result<String, XmlEncError> {
+    let mut writer = Writer::new(Vec::new());
+    let mut root = BytesStart::new("xenc:EncryptedData");
+    root.push_attribute(("xmlns:xenc", XMLENC_NS));
+    root.push_attribute(("xmlns:xenc11", XMLENC11_NS));
+    root.push_attribute(("xmlns:ds", XMLDSIG_NS));
+    if let Some(id) = id {
+        root.push_attribute(("Id", id));
+    }
+    if let Some(encrypted_type) = encrypted_type {
+        let uri = match encrypted_type {
+            EncryptedDataType::Element => format!("{XMLENC_NS}Element"),
+            EncryptedDataType::Content => format!("{XMLENC_NS}Content"),
+            EncryptedDataType::Other(uri) => uri.clone(),
+        };
+        root.push_attribute(("Type", uri.as_str()));
+    }
+    write_event(&mut writer, Event::Start(root))?;
+    write_empty_with_algorithm(&mut writer, "xenc:EncryptionMethod", algorithm.uri())?;
+
+    if direct_key_name.is_some() || !encrypted_keys.is_empty() {
+        write_event(&mut writer, Event::Start(BytesStart::new("ds:KeyInfo")))?;
+        if let Some(key_name) = direct_key_name {
+            write_text_element(&mut writer, "ds:KeyName", key_name)?;
+        }
+        for encrypted_key in encrypted_keys {
+            write_encrypted_key(&mut writer, encrypted_key)?;
+        }
+        write_event(&mut writer, Event::End(BytesEnd::new("ds:KeyInfo")))?;
+    }
+
+    write_cipher_data(&mut writer, ciphertext)?;
+    write_event(&mut writer, Event::End(BytesEnd::new("xenc:EncryptedData")))?;
+    String::from_utf8(writer.into_inner())
+        .map_err(|error| XmlEncError::XmlSerialize(error.to_string()))
+}
+
+fn write_encrypted_key(
+    writer: &mut Writer<Vec<u8>>,
+    encrypted_key: &WrappedKey,
+) -> Result<(), XmlEncError> {
+    let mut start = BytesStart::new("xenc:EncryptedKey");
+    if let Some(recipient) = encrypted_key.recipient.as_deref() {
+        start.push_attribute(("Recipient", recipient));
+    }
+    write_event(writer, Event::Start(start))?;
+
+    if let Some(parameters) = encrypted_key.oaep.as_ref() {
+        let mut method = BytesStart::new("xenc:EncryptionMethod");
+        method.push_attribute(("Algorithm", encrypted_key.algorithm_uri));
+        write_event(writer, Event::Start(method))?;
+        if !parameters.label.is_empty() {
+            write_text_element(
+                writer,
+                "xenc:OAEPparams",
+                &STANDARD.encode(&parameters.label),
+            )?;
+        }
+        write_empty_with_algorithm(writer, "ds:DigestMethod", parameters.digest.uri())?;
+        if parameters.algorithm == super::KeyTransportAlgorithm::RsaOaep11 {
+            write_empty_with_algorithm(writer, "xenc11:MGF", parameters.mgf_digest.mgf_uri())?;
+        }
+        write_event(writer, Event::End(BytesEnd::new("xenc:EncryptionMethod")))?;
+    } else {
+        write_empty_with_algorithm(writer, "xenc:EncryptionMethod", encrypted_key.algorithm_uri)?;
+    }
+
+    if let Some(key_name) = encrypted_key.key_name.as_deref() {
+        write_event(writer, Event::Start(BytesStart::new("ds:KeyInfo")))?;
+        write_text_element(writer, "ds:KeyName", key_name)?;
+        write_event(writer, Event::End(BytesEnd::new("ds:KeyInfo")))?;
+    }
+    write_cipher_data(writer, &encrypted_key.ciphertext)?;
+    write_event(writer, Event::End(BytesEnd::new("xenc:EncryptedKey")))
+}
+
+fn write_cipher_data(writer: &mut Writer<Vec<u8>>, value: &[u8]) -> Result<(), XmlEncError> {
+    write_event(writer, Event::Start(BytesStart::new("xenc:CipherData")))?;
+    write_text_element(writer, "xenc:CipherValue", &STANDARD.encode(value))?;
+    write_event(writer, Event::End(BytesEnd::new("xenc:CipherData")))
+}
+
+fn write_empty_with_algorithm(
+    writer: &mut Writer<Vec<u8>>,
+    name: &str,
+    algorithm: &str,
+) -> Result<(), XmlEncError> {
+    let mut element = BytesStart::new(name);
+    element.push_attribute(("Algorithm", algorithm));
+    write_event(writer, Event::Empty(element))
+}
+
+fn write_text_element(
+    writer: &mut Writer<Vec<u8>>,
+    name: &str,
+    text: &str,
+) -> Result<(), XmlEncError> {
+    write_event(writer, Event::Start(BytesStart::new(name)))?;
+    write_event(writer, Event::Text(BytesText::new(text)))?;
+    write_event(writer, Event::End(BytesEnd::new(name)))
+}
+
+fn write_event(writer: &mut Writer<Vec<u8>>, event: Event<'_>) -> Result<(), XmlEncError> {
+    writer
+        .write_event(event)
+        .map_err(|error| XmlEncError::XmlSerialize(error.to_string()))
+}
+
+fn validate_xml_plaintext(
+    xml: &str,
+    encrypted_type: &EncryptedDataType,
+) -> Result<(), XmlEncError> {
+    match encrypted_type {
+        EncryptedDataType::Element => {
+            let document = Document::parse(xml)?;
+            if document.root().children().filter(Node::is_element).count() != 1 {
+                return Err(XmlEncError::InvalidStructure(
+                    "Element plaintext must contain exactly one element".into(),
+                ));
+            }
+            Ok(())
+        }
+        EncryptedDataType::Content => {
+            let wrapped = format!("<xmlsec-content>{xml}</xmlsec-content>");
+            let _ = Document::parse(&wrapped)?;
+            Ok(())
+        }
+        EncryptedDataType::Other(_) => Err(XmlEncError::InvalidEncryptionConfig(
+            "encrypt_xml requires Element or Content Type".into(),
+        )),
+    }
+}
+
+fn select_encryption_target<'a, 'input>(
+    document: &'a Document<'input>,
+    id: Option<&str>,
+) -> Result<Node<'a, 'input>, XmlEncError> {
+    let Some(id) = id else {
+        return Ok(document.root_element());
+    };
+    let mut matches = document.descendants().filter(|node| {
+        node.is_element()
+            && ["Id", "ID", "id"]
+                .iter()
+                .any(|name| node.attribute(*name) == Some(id))
+    });
+    let selected = matches
+        .next()
+        .ok_or(XmlEncError::EncryptionTargetNotFound)?;
+    if matches.next().is_some() {
+        return Err(XmlEncError::AmbiguousEncryptionTarget);
+    }
+    Ok(selected)
+}
+
+fn element_content_boundaries(source: &str) -> Result<ContentBoundaries, XmlEncError> {
+    let tag_end = find_start_tag_end(source)?;
+    let before_end = source[..tag_end].trim_end_matches(XML_WHITESPACE);
+    let self_closing = before_end.ends_with('/');
+    let name_end = source[1..]
+        .find(|character: char| character.is_ascii_whitespace() || matches!(character, '/' | '>'))
+        .map(|index| index + 1)
+        .ok_or_else(|| XmlEncError::InvalidStructure("source element has no name".into()))?;
+    let qualified_name = source[1..name_end].to_owned();
+    if self_closing {
+        return Ok(ContentBoundaries {
+            content: tag_end..tag_end,
+            self_closing: true,
+            qualified_name,
+            start_tag_end: tag_end,
+        });
+    }
+    let closing_start = source
+        .rfind("</")
+        .ok_or_else(|| XmlEncError::InvalidStructure("source element has no closing tag".into()))?;
+    Ok(ContentBoundaries {
+        content: tag_end + 1..closing_start,
+        self_closing: false,
+        qualified_name,
+        start_tag_end: tag_end,
+    })
+}
+
+fn find_start_tag_end(source: &str) -> Result<usize, XmlEncError> {
+    let mut quote = None;
+    for (index, character) in source.char_indices() {
+        match (quote, character) {
+            (Some(expected), actual) if expected == actual => quote = None,
+            (None, '\'' | '"') => quote = Some(character),
+            (None, '>') => return Ok(index),
+            _ => {}
+        }
+    }
+    Err(XmlEncError::InvalidStructure(
+        "source element start tag is unterminated".into(),
+    ))
+}
+
+fn replace_element_content(
+    xml: &str,
+    range: std::ops::Range<usize>,
+    source: &str,
+    boundaries: ContentBoundaries,
+    encrypted_data: &str,
+) -> Result<String, XmlEncError> {
+    if !boundaries.self_closing {
+        let absolute = range.start + boundaries.content.start..range.start + boundaries.content.end;
+        return Ok(replace_range(xml, absolute, encrypted_data));
+    }
+
+    let slash = source[..boundaries.start_tag_end]
+        .rfind('/')
+        .ok_or_else(|| XmlEncError::InvalidStructure("self-closing tag has no slash".into()))?;
+    let mut expanded = String::with_capacity(source.len() + encrypted_data.len() + 16);
+    expanded.push_str(&source[..slash]);
+    expanded.push('>');
+    expanded.push_str(encrypted_data);
+    expanded.push_str("</");
+    expanded.push_str(&boundaries.qualified_name);
+    expanded.push('>');
+    Ok(replace_range(xml, range, &expanded))
+}
+
+fn replace_range(xml: &str, range: std::ops::Range<usize>, replacement: &str) -> String {
+    let mut output = String::with_capacity(xml.len() - range.len() + replacement.len());
+    output.push_str(&xml[..range.start]);
+    output.push_str(replacement);
+    output.push_str(&xml[range.end..]);
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use getrandom::rand_core::UnwrapErr;
+    use rsa::{RsaPrivateKey, RsaPublicKey};
+
+    use super::*;
+    use crate::xmlenc::{
+        KekDecryptor, PrivateKeyDecryptor, SymmetricKeyDecryptor, decrypt, decrypt_document,
+        parse_encrypted_data,
+    };
+
+    #[test]
+    fn direct_key_round_trips_every_content_algorithm() {
+        // All emitted wire layouts must be accepted by the existing independent
+        // decrypt path, including empty plaintext and full-block CBC padding.
+        for algorithm in [
+            DataEncryptionAlgorithm::Aes128Cbc,
+            DataEncryptionAlgorithm::Aes256Cbc,
+            DataEncryptionAlgorithm::Aes128Gcm,
+            DataEncryptionAlgorithm::Aes256Gcm,
+        ] {
+            for plaintext in [b"".as_slice(), b"sixteen-byte-msg", b"not aligned"] {
+                let key = vec![0x31; algorithm.key_len()];
+                let encrypted = EncryptedDataBuilder::new(algorithm)
+                    .direct_key(key.clone())
+                    .direct_key_name("content-key")
+                    .encrypt_binary(plaintext)
+                    .expect("supported direct encryption must succeed");
+                assert_eq!(
+                    decrypt(
+                        &encrypted.encrypted_data_xml,
+                        &SymmetricKeyDecryptor::new(key)
+                    )
+                    .expect("generated ciphertext must decrypt"),
+                    super::super::DecryptedContent::Bytes(plaintext.to_vec())
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn aes_key_wrap_round_trips_and_preserves_recipient_metadata() {
+        let kek = [0x44; 32];
+        let encrypted = EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm)
+            .add_recipient(
+                EncryptionRecipient::aes_key_wrap(kek, KeyWrapAlgorithm::AesKw256)
+                    .recipient("service-a")
+                    .key_name("shared-kek"),
+            )
+            .encrypt_xml("<secret>value</secret>")
+            .expect("AES-KW encryption must succeed");
+        let parsed = parse_encrypted_data(&encrypted.encrypted_data_xml)
+            .expect("generated EncryptedData must parse");
+        assert_eq!(
+            parsed.encrypted_keys[0].recipient.as_deref(),
+            Some("service-a")
+        );
+        assert_eq!(
+            parsed.encrypted_keys[0].key_name.as_deref(),
+            Some("shared-kek")
+        );
+        assert_eq!(
+            decrypt(&encrypted.encrypted_data_xml, &KekDecryptor::new(kek))
+                .expect("wrapped key must decrypt"),
+            super::super::DecryptedContent::Xml("<secret>value</secret>".into())
+        );
+    }
+
+    #[test]
+    fn rsa_oaep_round_trips_configurable_parameters() {
+        let private = RsaPrivateKey::new(&mut UnwrapErr(SysRng), 2048)
+            .expect("test RSA key generation must succeed");
+        let public = RsaPublicKey::from(&private);
+        let parameters =
+            RsaOaepParameters::xmlenc11(OaepDigestAlgorithm::Sha256, OaepDigestAlgorithm::Sha512)
+                .label(b"recipient-label".to_vec());
+        let encrypted = EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes256Gcm)
+            .add_recipient(
+                EncryptionRecipient::rsa_oaep(public)
+                    .oaep_parameters(parameters)
+                    .recipient("rsa-recipient"),
+            )
+            .encrypt_xml("<secret/>")
+            .expect("RSA-OAEP encryption must succeed");
+        assert_eq!(
+            decrypt(
+                &encrypted.encrypted_data_xml,
+                &PrivateKeyDecryptor::new(private)
+            )
+            .expect("RSA recipient must recover content key"),
+            super::super::DecryptedContent::Xml("<secret/>".into())
+        );
+    }
+
+    #[test]
+    fn encrypt_document_replaces_element_and_self_closing_content() {
+        let key = [0x55; 16];
+        let document =
+            "<root><target ID=\"element\"><child/></target><empty ID=\"content\"/></root>";
+        let encrypted_element = EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm)
+            .direct_key(key)
+            .encrypt_document(
+                document,
+                DocumentEncryptionOptions {
+                    element_id: Some("element"),
+                    allow_dtd: false,
+                },
+            )
+            .expect("element replacement must succeed");
+        let decrypted_element =
+            decrypt_document(&encrypted_element, None, &SymmetricKeyDecryptor::new(key))
+                .expect("element replacement must round-trip");
+        assert_eq!(decrypted_element, document);
+
+        let encrypted_content = EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm)
+            .encryption_type(EncryptedDataType::Content)
+            .direct_key(key)
+            .encrypt_document(
+                document,
+                DocumentEncryptionOptions {
+                    element_id: Some("content"),
+                    allow_dtd: false,
+                },
+            )
+            .expect("self-closing content replacement must expand the element");
+        assert!(encrypted_content.contains("<empty ID=\"content\"><xenc:EncryptedData"));
+        let decrypted_content =
+            decrypt_document(&encrypted_content, None, &SymmetricKeyDecryptor::new(key))
+                .expect("empty content must decrypt");
+        assert_eq!(
+            decrypted_content,
+            "<root><target ID=\"element\"><child/></target><empty ID=\"content\"></empty></root>"
+        );
+    }
+
+    #[test]
+    fn invalid_configuration_and_bounds_fail_before_encryption() {
+        let no_key = EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm)
+            .encrypt_binary(b"data")
+            .expect_err("missing key source must fail");
+        assert!(matches!(no_key, XmlEncError::InvalidEncryptionConfig(_)));
+
+        assert!(validate_plaintext_len(MAX_ENCRYPTION_PLAINTEXT_LEN).is_ok());
+        assert!(matches!(
+            validate_plaintext_len(MAX_ENCRYPTION_PLAINTEXT_LEN + 1),
+            Err(XmlEncError::PlaintextTooLarge { .. })
+        ));
+
+        assert!(matches!(
+            EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm)
+                .direct_key([0_u8; 15])
+                .encrypt_binary(b"data"),
+            Err(XmlEncError::InvalidKeySize { .. })
+        ));
+
+        let too_many_recipients = (0..=MAX_ENCRYPTION_RECIPIENTS).fold(
+            EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm),
+            |builder, _| builder.recipient_aes_kw([0_u8; 16], KeyWrapAlgorithm::AesKw128),
+        );
+        assert!(matches!(
+            too_many_recipients.encrypt_binary(b"data"),
+            Err(XmlEncError::TooManyRecipients { .. })
+        ));
+
+        let oversized_metadata = "x".repeat(MAX_ENCRYPTION_METADATA_LEN + 1);
+        assert!(matches!(
+            EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm)
+                .direct_key([0_u8; 16])
+                .id(oversized_metadata)
+                .encrypt_binary(b"data"),
+            Err(XmlEncError::EncryptionMetadataTooLarge { .. })
+        ));
+    }
+
+    #[test]
+    fn debug_output_redacts_symmetric_key_material() {
+        let direct_key = b"direct-key-secret".to_vec();
+        let kek = b"key-wrap-secret!".to_vec();
+        let builder = EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm)
+            .direct_key(direct_key.clone());
+        let recipient = EncryptionRecipient::aes_key_wrap(kek.clone(), KeyWrapAlgorithm::AesKw128);
+
+        let builder_debug = format!("{builder:?}");
+        let recipient_debug = format!("{recipient:?}");
+        assert!(builder_debug.contains("[REDACTED]"));
+        assert!(recipient_debug.contains("[REDACTED]"));
+        assert!(!builder_debug.contains(&format!("{direct_key:?}")));
+        assert!(!recipient_debug.contains(&format!("{kek:?}")));
+    }
+}

--- a/src/xmlenc/encrypt.rs
+++ b/src/xmlenc/encrypt.rs
@@ -1041,6 +1041,44 @@ mod tests {
     }
 
     #[test]
+    fn xml_forbidden_metadata_characters_are_rejected() {
+        // XML escaping cannot legalize forbidden XML 1.0 code points, so every
+        // caller-controlled attribute/text path must fail before serialization.
+        assert!(matches!(
+            EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm)
+                .direct_key([0_u8; 16])
+                .id("invalid\0id")
+                .encrypt_binary(b"data"),
+            Err(XmlEncError::InvalidEncryptionConfig(_))
+        ));
+        assert!(matches!(
+            EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm)
+                .direct_key([0_u8; 16])
+                .direct_key_name("invalid\0name")
+                .encrypt_binary(b"data"),
+            Err(XmlEncError::InvalidEncryptionConfig(_))
+        ));
+        assert!(matches!(
+            EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm)
+                .add_recipient(
+                    EncryptionRecipient::aes_key_wrap([0_u8; 16], KeyWrapAlgorithm::AesKw128)
+                        .recipient("invalid\0recipient")
+                )
+                .encrypt_binary(b"data"),
+            Err(XmlEncError::InvalidEncryptionConfig(_))
+        ));
+        assert!(matches!(
+            EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm)
+                .add_recipient(
+                    EncryptionRecipient::aes_key_wrap([0_u8; 16], KeyWrapAlgorithm::AesKw128)
+                        .key_name("invalid\0name")
+                )
+                .encrypt_binary(b"data"),
+            Err(XmlEncError::InvalidEncryptionConfig(_))
+        ));
+    }
+
+    #[test]
     fn debug_output_redacts_symmetric_key_material() {
         let direct_key = b"direct-key-secret".to_vec();
         let kek = b"key-wrap-secret!".to_vec();

--- a/src/xmlenc/mod.rs
+++ b/src/xmlenc/mod.rs
@@ -1,8 +1,18 @@
 //! XML Encryption (XMLEnc).
 //!
 //! Implements [XML Encryption Syntax and Processing](https://www.w3.org/TR/xmlenc-core1/).
+//!
+//! `EncryptedDataBuilder` encrypts opaque bytes, XML elements, XML content, or
+//! a selected node in a caller-owned document. It supports direct AES content
+//! keys and generated session keys wrapped independently for one or more
+//! RSA-OAEP or AES-KW recipients. The reciprocal decrypt APIs accept the same
+//! inline `CipherValue` profile.
+//!
+//! External `CipherReference` resources, RSA PKCS#1 v1.5 key transport, and
+//! unauthenticated legacy ciphers are intentionally outside this profile.
 
 mod decrypt;
+mod encrypt;
 mod parse;
 mod types;
 
@@ -10,9 +20,11 @@ pub use decrypt::{
     DecryptionKeyResolver, DocumentDecryptionOptions, KekDecryptor, PrivateKeyDecryptor,
     SymmetricKeyDecryptor, decrypt, decrypt_data, decrypt_document, decrypt_document_with_options,
 };
+pub use encrypt::EncryptedDataBuilder;
 pub use parse::parse_encrypted_data;
 pub use types::{
-    CipherData, DataEncryptionAlgorithm, DecryptedContent, EncryptedData, EncryptedDataType,
-    EncryptedKey, EncryptionMethod, KeyTransportAlgorithm, KeyWrapAlgorithm, ReferenceList,
-    XmlEncError,
+    CipherData, DataEncryptionAlgorithm, DecryptedContent, DocumentEncryptionOptions,
+    EncryptedData, EncryptedDataType, EncryptedKey, EncryptionMethod, EncryptionRecipient,
+    EncryptionResult, KeyTransportAlgorithm, KeyWrapAlgorithm, OaepDigestAlgorithm, ReferenceList,
+    ReplacementMode, RsaOaepParameters, XmlEncError,
 };

--- a/src/xmlenc/mod.rs
+++ b/src/xmlenc/mod.rs
@@ -11,6 +11,8 @@
 //! External `CipherReference` resources, RSA PKCS#1 v1.5 key transport, and
 //! unauthenticated legacy ciphers are intentionally outside this profile.
 
+use roxmltree::Node;
+
 mod decrypt;
 mod encrypt;
 mod parse;
@@ -28,3 +30,25 @@ pub use types::{
     EncryptionResult, KeyTransportAlgorithm, KeyWrapAlgorithm, OaepDigestAlgorithm, ReferenceList,
     ReplacementMode, RsaOaepParameters, XmlEncError,
 };
+
+fn has_single_element_with_boundary_trivia(parent: Node<'_, '_>) -> bool {
+    let mut element_count = 0;
+    let valid_children = parent.children().all(|node| {
+        if node.is_element() {
+            element_count += 1;
+            true
+        } else if node.is_comment() {
+            true
+        } else if node.is_text() {
+            // XML permits boundary whitespace around a document element; processing
+            // instructions and every other node kind are unsafe replacement payloads.
+            node.text().is_some_and(|text| {
+                text.chars()
+                    .all(|character| matches!(character, ' ' | '\t' | '\n' | '\r'))
+            })
+        } else {
+            false
+        }
+    });
+    valid_children && element_count == 1
+}

--- a/src/xmlenc/mod.rs
+++ b/src/xmlenc/mod.rs
@@ -33,22 +33,26 @@ pub use types::{
 
 fn has_single_element_with_boundary_trivia(parent: Node<'_, '_>) -> bool {
     let mut element_count = 0;
-    let valid_children = parent.children().all(|node| {
+    for node in parent.children() {
         if node.is_element() {
             element_count += 1;
-            true
+            if element_count > 1 {
+                return false;
+            }
         } else if node.is_comment() {
-            true
+            continue;
         } else if node.is_text() {
             // XML permits boundary whitespace around a document element; processing
             // instructions and every other node kind are unsafe replacement payloads.
-            node.text().is_some_and(|text| {
+            if !node.text().is_some_and(|text| {
                 text.chars()
                     .all(|character| matches!(character, ' ' | '\t' | '\n' | '\r'))
-            })
+            }) {
+                return false;
+            }
         } else {
-            false
+            return false;
         }
-    });
-    valid_children && element_count == 1
+    }
+    element_count == 1
 }

--- a/src/xmlenc/types.rs
+++ b/src/xmlenc/types.rs
@@ -2,6 +2,8 @@
 
 use std::fmt;
 
+use rsa::RsaPublicKey;
+
 /// XML Encryption 1.0 namespace.
 pub const XMLENC_NS: &str = "http://www.w3.org/2001/04/xmlenc#";
 /// XML Encryption 1.1 namespace.
@@ -11,6 +13,15 @@ pub const XMLDSIG_NS: &str = "http://www.w3.org/2000/09/xmldsig#";
 
 /// Maximum normalized base64 text accepted from a `CipherValue`.
 pub const MAX_CIPHER_VALUE_BASE64_LEN: usize = 16 * 1024 * 1024;
+/// Maximum plaintext accepted by the encryption API.
+///
+/// The limit leaves room for CBC/GCM framing while guaranteeing that the
+/// resulting base64 `CipherValue` fits the parser's input bound.
+pub const MAX_ENCRYPTION_PLAINTEXT_LEN: usize = (MAX_CIPHER_VALUE_BASE64_LEN / 4 * 3) - 32;
+/// Maximum number of independently wrapped copies of one content key.
+pub const MAX_ENCRYPTION_RECIPIENTS: usize = 64;
+/// Maximum byte length of one caller-controlled XML metadata value.
+pub const MAX_ENCRYPTION_METADATA_LEN: usize = 4 * 1024;
 
 /// The `Type` attribute on an `EncryptedData` element.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -55,6 +66,16 @@ impl DataEncryptionAlgorithm {
             Self::Aes256Cbc | Self::Aes256Gcm => 32,
         }
     }
+
+    /// Return the standard XMLEnc algorithm URI.
+    pub const fn uri(self) -> &'static str {
+        match self {
+            Self::Aes128Cbc => "http://www.w3.org/2001/04/xmlenc#aes128-cbc",
+            Self::Aes256Cbc => "http://www.w3.org/2001/04/xmlenc#aes256-cbc",
+            Self::Aes128Gcm => "http://www.w3.org/2009/xmlenc11#aes128-gcm",
+            Self::Aes256Gcm => "http://www.w3.org/2009/xmlenc11#aes256-gcm",
+        }
+    }
 }
 
 impl KeyTransportAlgorithm {
@@ -64,6 +85,14 @@ impl KeyTransportAlgorithm {
             "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p" => Ok(Self::RsaOaepMgf1p),
             "http://www.w3.org/2009/xmlenc11#rsa-oaep" => Ok(Self::RsaOaep11),
             _ => Err(XmlEncError::UnsupportedAlgorithm(uri.to_owned())),
+        }
+    }
+
+    /// Return the standard XMLEnc key-transport URI.
+    pub const fn uri(self) -> &'static str {
+        match self {
+            Self::RsaOaepMgf1p => "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p",
+            Self::RsaOaep11 => "http://www.w3.org/2009/xmlenc11#rsa-oaep",
         }
     }
 }
@@ -85,6 +114,14 @@ impl KeyWrapAlgorithm {
             Self::AesKw256 => 32,
         }
     }
+
+    /// Return the standard XMLEnc key-wrap URI.
+    pub const fn uri(self) -> &'static str {
+        match self {
+            Self::AesKw128 => "http://www.w3.org/2001/04/xmlenc#kw-aes128",
+            Self::AesKw256 => "http://www.w3.org/2001/04/xmlenc#kw-aes256",
+        }
+    }
 }
 
 /// Supported asymmetric session-key transport algorithms.
@@ -103,6 +140,227 @@ pub enum KeyWrapAlgorithm {
     AesKw128,
     /// RFC 3394 AES key wrap with a 256-bit KEK.
     AesKw256,
+}
+
+/// Digest algorithms accepted by RSA-OAEP encryption.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OaepDigestAlgorithm {
+    /// SHA-1, retained for legacy XMLEnc OAEP interoperability.
+    Sha1,
+    /// SHA-256.
+    Sha256,
+    /// SHA-384.
+    Sha384,
+    /// SHA-512.
+    Sha512,
+}
+
+impl OaepDigestAlgorithm {
+    /// Return the standard digest URI.
+    pub const fn uri(self) -> &'static str {
+        match self {
+            Self::Sha1 => "http://www.w3.org/2000/09/xmldsig#sha1",
+            Self::Sha256 => "http://www.w3.org/2001/04/xmlenc#sha256",
+            Self::Sha384 => "http://www.w3.org/2001/04/xmlenc#sha384",
+            Self::Sha512 => "http://www.w3.org/2001/04/xmlenc#sha512",
+        }
+    }
+
+    /// Return the XML Encryption 1.1 MGF URI for this digest.
+    pub const fn mgf_uri(self) -> &'static str {
+        match self {
+            Self::Sha1 => "http://www.w3.org/2009/xmlenc11#mgf1sha1",
+            Self::Sha256 => "http://www.w3.org/2009/xmlenc11#mgf1sha256",
+            Self::Sha384 => "http://www.w3.org/2009/xmlenc11#mgf1sha384",
+            Self::Sha512 => "http://www.w3.org/2009/xmlenc11#mgf1sha512",
+        }
+    }
+}
+
+/// RSA-OAEP parameters emitted in an `EncryptedKey`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RsaOaepParameters {
+    /// XMLEnc 1.0 legacy OAEP or XMLEnc 1.1 configurable OAEP.
+    pub algorithm: KeyTransportAlgorithm,
+    /// Digest used by OAEP.
+    pub digest: OaepDigestAlgorithm,
+    /// Digest used by MGF1.
+    pub mgf_digest: OaepDigestAlgorithm,
+    /// Optional OAEP label bytes.
+    pub label: Vec<u8>,
+}
+
+impl RsaOaepParameters {
+    /// Create legacy OAEP parameters with SHA-1 and MGF1-SHA-1.
+    pub fn legacy() -> Self {
+        Self {
+            algorithm: KeyTransportAlgorithm::RsaOaepMgf1p,
+            digest: OaepDigestAlgorithm::Sha1,
+            mgf_digest: OaepDigestAlgorithm::Sha1,
+            label: Vec::new(),
+        }
+    }
+
+    /// Create XMLEnc 1.1 OAEP parameters.
+    pub fn xmlenc11(digest: OaepDigestAlgorithm, mgf_digest: OaepDigestAlgorithm) -> Self {
+        Self {
+            algorithm: KeyTransportAlgorithm::RsaOaep11,
+            digest,
+            mgf_digest,
+            label: Vec::new(),
+        }
+    }
+
+    /// Set the OAEP label bytes.
+    pub fn label(mut self, label: impl Into<Vec<u8>>) -> Self {
+        self.label = label.into();
+        self
+    }
+}
+
+impl Default for RsaOaepParameters {
+    fn default() -> Self {
+        Self::xmlenc11(OaepDigestAlgorithm::Sha256, OaepDigestAlgorithm::Sha256)
+    }
+}
+
+/// One recipient of a generated content-encryption key.
+#[derive(Clone)]
+pub enum EncryptionRecipient {
+    /// Wrap the content key with an RSA public key and OAEP.
+    RsaOaep {
+        /// Recipient public key.
+        public_key: RsaPublicKey,
+        /// OAEP algorithm parameters.
+        parameters: RsaOaepParameters,
+        /// Optional `Recipient` attribute.
+        recipient: Option<String>,
+        /// Optional key hint inside the encrypted key's `KeyInfo`.
+        key_name: Option<String>,
+    },
+    /// Wrap the content key with a pre-shared AES KEK.
+    AesKeyWrap {
+        /// AES key-encryption key.
+        kek: Vec<u8>,
+        /// RFC 3394 key-wrap variant.
+        algorithm: KeyWrapAlgorithm,
+        /// Optional `Recipient` attribute.
+        recipient: Option<String>,
+        /// Optional key hint inside the encrypted key's `KeyInfo`.
+        key_name: Option<String>,
+    },
+}
+
+impl fmt::Debug for EncryptionRecipient {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::RsaOaep {
+                parameters,
+                recipient,
+                key_name,
+                ..
+            } => formatter
+                .debug_struct("EncryptionRecipient::RsaOaep")
+                .field("public_key", &"[PUBLIC KEY]")
+                .field("parameters", parameters)
+                .field("recipient", recipient)
+                .field("key_name", key_name)
+                .finish(),
+            Self::AesKeyWrap {
+                algorithm,
+                recipient,
+                key_name,
+                ..
+            } => formatter
+                .debug_struct("EncryptionRecipient::AesKeyWrap")
+                .field("kek", &"[REDACTED]")
+                .field("algorithm", algorithm)
+                .field("recipient", recipient)
+                .field("key_name", key_name)
+                .finish(),
+        }
+    }
+}
+
+impl EncryptionRecipient {
+    /// Create an RSA-OAEP recipient with secure XMLEnc 1.1 defaults.
+    pub fn rsa_oaep(public_key: RsaPublicKey) -> Self {
+        Self::RsaOaep {
+            public_key,
+            parameters: RsaOaepParameters::default(),
+            recipient: None,
+            key_name: None,
+        }
+    }
+
+    /// Create an AES Key Wrap recipient.
+    pub fn aes_key_wrap(kek: impl Into<Vec<u8>>, algorithm: KeyWrapAlgorithm) -> Self {
+        Self::AesKeyWrap {
+            kek: kek.into(),
+            algorithm,
+            recipient: None,
+            key_name: None,
+        }
+    }
+
+    /// Override RSA-OAEP parameters.
+    pub fn oaep_parameters(mut self, parameters: RsaOaepParameters) -> Self {
+        if let Self::RsaOaep {
+            parameters: current,
+            ..
+        } = &mut self
+        {
+            *current = parameters;
+        }
+        self
+    }
+
+    /// Set the recipient identifier emitted on `EncryptedKey`.
+    pub fn recipient(mut self, value: impl Into<String>) -> Self {
+        match &mut self {
+            Self::RsaOaep { recipient, .. } | Self::AesKeyWrap { recipient, .. } => {
+                *recipient = Some(value.into());
+            }
+        }
+        self
+    }
+
+    /// Set the key name emitted inside the encrypted key's `KeyInfo`.
+    pub fn key_name(mut self, value: impl Into<String>) -> Self {
+        match &mut self {
+            Self::RsaOaep { key_name, .. } | Self::AesKeyWrap { key_name, .. } => {
+                *key_name = Some(value.into());
+            }
+        }
+        self
+    }
+}
+
+/// How generated `EncryptedData` replaces caller-owned XML.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplacementMode {
+    /// Replace the selected element, including its start and end tags.
+    ReplaceElement,
+    /// Replace only the selected element's child content.
+    ReplaceContent,
+}
+
+/// Result returned after encrypting bytes or XML.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EncryptionResult {
+    /// Complete `EncryptedData` XML fragment.
+    pub encrypted_data_xml: String,
+    /// Required caller-owned document replacement operation.
+    pub replacement: ReplacementMode,
+}
+
+/// XML parser controls and target selection for document encryption.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DocumentEncryptionOptions<'a> {
+    /// Select an element by `Id`, `ID`, or `id`; `None` selects the document root.
+    pub element_id: Option<&'a str>,
+    /// Permit an internal DTD subset while parsing the caller's document.
+    pub allow_dtd: bool,
 }
 
 /// Parsed `EncryptionMethod` data.
@@ -181,7 +439,7 @@ pub enum DecryptedContent {
     Bytes(Vec<u8>),
 }
 
-/// Errors raised while parsing, resolving, or decrypting XMLEnc data.
+/// Errors raised while parsing, encrypting, resolving, or decrypting XMLEnc data.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum XmlEncError {
@@ -244,6 +502,35 @@ pub enum XmlEncError {
         /// Actual KEK size.
         actual: usize,
     },
+    /// Plaintext exceeds the bounded encryption input size.
+    #[error("encryption plaintext exceeds {maximum}-byte limit: got {actual} bytes")]
+    PlaintextTooLarge {
+        /// Maximum accepted bytes.
+        maximum: usize,
+        /// Actual input bytes.
+        actual: usize,
+    },
+    /// More independently wrapped recipient keys were configured than allowed.
+    #[error("encryption recipient count exceeds {maximum}: got {actual}")]
+    TooManyRecipients {
+        /// Maximum supported recipients.
+        maximum: usize,
+        /// Actual configured recipients.
+        actual: usize,
+    },
+    /// Caller-controlled XML metadata exceeds the generated-output bound.
+    #[error("{field} exceeds {maximum}-byte encryption metadata limit: got {actual} bytes")]
+    EncryptionMetadataTooLarge {
+        /// Metadata field being validated.
+        field: &'static str,
+        /// Maximum accepted bytes.
+        maximum: usize,
+        /// Actual input bytes.
+        actual: usize,
+    },
+    /// Encryption configuration is internally inconsistent.
+    #[error("invalid encryption configuration: {0}")]
+    InvalidEncryptionConfig(String),
     /// No caller-provided resolver could supply a usable key.
     #[error("no suitable decryption key was resolved")]
     KeyNotFound,
@@ -253,15 +540,30 @@ pub enum XmlEncError {
     /// More than one `EncryptedData` matched the requested document selection.
     #[error("more than one EncryptedData element matched; select one by Id")]
     AmbiguousEncryptedData,
+    /// No source element matched the requested encryption target.
+    #[error("no matching element was found for encryption")]
+    EncryptionTargetNotFound,
+    /// More than one source element matched the requested encryption target.
+    #[error("more than one element matched the encryption target")]
+    AmbiguousEncryptionTarget,
     /// Document replacement requires an XML `Type` declaration.
     #[error("EncryptedData must declare Element or Content Type for document replacement")]
     ReplacementRequiresXml,
     /// RSA-OAEP session-key recovery failed.
     #[error("RSA-OAEP key unwrap failed: {0}")]
     Rsa(String),
+    /// RSA-OAEP session-key wrapping failed.
+    #[error("RSA-OAEP key wrap failed: {0}")]
+    RsaEncrypt(String),
     /// RFC 3394 integrity validation failed while unwrapping a key.
     #[error("AES key unwrap failed integrity validation")]
     KeyWrapIntegrity,
+    /// Operating-system randomness was unavailable.
+    #[error("operating-system random number generation failed: {0}")]
+    Rng(String),
+    /// Generated XML could not be serialized.
+    #[error("XML encryption serialization failed: {0}")]
+    XmlSerialize(String),
     /// XML-declared plaintext could not be decoded as UTF-8.
     #[error("decrypted XML is not valid UTF-8: {0}")]
     Utf8(#[from] std::string::FromUtf8Error),

--- a/src/xmlenc/types.rs
+++ b/src/xmlenc/types.rs
@@ -18,6 +18,11 @@ pub const MAX_CIPHER_VALUE_BASE64_LEN: usize = 16 * 1024 * 1024;
 /// The limit leaves room for CBC/GCM framing while guaranteeing that the
 /// resulting base64 `CipherValue` fits the parser's input bound.
 pub const MAX_ENCRYPTION_PLAINTEXT_LEN: usize = (MAX_CIPHER_VALUE_BASE64_LEN / 4 * 3) - 32;
+/// Maximum caller-owned XML document size accepted for node encryption.
+///
+/// This separately bounds parser work while leaving room around a maximum-size
+/// selected plaintext element or content fragment.
+pub const MAX_ENCRYPTION_DOCUMENT_LEN: usize = MAX_CIPHER_VALUE_BASE64_LEN;
 /// Maximum number of independently wrapped copies of one content key.
 pub const MAX_ENCRYPTION_RECIPIENTS: usize = 64;
 /// Maximum byte length of one caller-controlled XML metadata value.
@@ -508,6 +513,14 @@ pub enum XmlEncError {
         /// Maximum accepted bytes.
         maximum: usize,
         /// Actual input bytes.
+        actual: usize,
+    },
+    /// Caller-owned XML exceeds the bounded document parser input size.
+    #[error("encryption document exceeds {maximum}-byte limit: got {actual} bytes")]
+    DocumentTooLarge {
+        /// Maximum accepted document bytes.
+        maximum: usize,
+        /// Actual document bytes.
         actual: usize,
     },
     /// More independently wrapped recipient keys were configured than allowed.

--- a/tests/fixtures/xmlenc/aleksey-xmlenc-01/enc-aes128cbc-keyname.tmpl
+++ b/tests/fixtures/xmlenc/aleksey-xmlenc-01/enc-aes128cbc-keyname.tmpl
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EncryptedData xmlns="http://www.w3.org/2001/04/xmlenc#" MimeType="text/plain">
+  <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes128-cbc" />
+  <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+     <KeyName>
+	test-aes128
+    </KeyName>
+  </KeyInfo>   
+  <CipherData>
+     <CipherValue>
+     </CipherValue>
+  </CipherData>
+</EncryptedData>

--- a/tests/fixtures/xmlenc/aleksey-xmlenc-01/enc-aes128gcm-keyname.tmpl
+++ b/tests/fixtures/xmlenc/aleksey-xmlenc-01/enc-aes128gcm-keyname.tmpl
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EncryptedData xmlns="http://www.w3.org/2001/04/xmlenc#"
+               xmlns:xenc11="http://www.w3.org/2009/xmlenc11#"
+               MimeType="text/plain">
+  <EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes128-gcm"/>
+  <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+    <KeyName>test-aes128</KeyName>
+  </KeyInfo>
+  <CipherData>
+    <CipherValue/>
+  </CipherData>
+</EncryptedData>

--- a/tests/fixtures/xmlenc/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_enc11_sha512_mgf1_sha512.tmpl
+++ b/tests/fixtures/xmlenc/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_enc11_sha512_mgf1_sha512.tmpl
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EncryptedData Id="ED" Type="http://www.w3.org/2001/04/xmlenc#Content"
+  xmlns="http://www.w3.org/2001/04/xmlenc#" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+  xmlns:xenc11="http://www.w3.org/2009/xmlenc11#">
+
+  <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-cbc"/>
+	<ds:KeyInfo>
+	  <EncryptedKey Id="EK">
+ 		  <EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#rsa-oaep">
+  		  <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha512"/>
+        <xenc11:MGF Algorithm="http://www.w3.org/2009/xmlenc11#mgf1sha512" />
+      </EncryptionMethod>
+      <ds:KeyInfo>
+        <ds:KeyName>TestKeyName-rsa-4096</ds:KeyName>
+      </ds:KeyInfo>
+      <CipherData>
+        <CipherValue/>
+      </CipherData>
+    </EncryptedKey>
+  </ds:KeyInfo>
+  <CipherData>
+    <CipherValue/>
+  </CipherData>
+</EncryptedData>

--- a/tests/fixtures/xmlenc/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha1-params.tmpl
+++ b/tests/fixtures/xmlenc/aleksey-xmlenc-01/enc-aes256-kt-rsa_oaep_sha1-params.tmpl
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EncryptedData Id="ED" Type="http://www.w3.org/2001/04/xmlenc#Content" xmlns="http://www.w3.org/2001/04/xmlenc#">
+	      <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-cbc"/>
+		<ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+		  <EncryptedKey Id="EK" xmlns="http://www.w3.org/2001/04/xmlenc#">
+ 		    <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p">
+  		      <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1" xmlns:ds="http://www.w3.org/2000/09/xmldsig#"/>
+                        <OAEPparams>MTIzNDU2Nzg=</OAEPparams>
+                    </EncryptionMethod>
+	        <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
+                  <ds:KeyName>TestKeyName-rsa-4096</ds:KeyName>
+                   </ds:KeyInfo>
+                   <CipherData>
+                     <CipherValue>
+                     </CipherValue>
+                   </CipherData>
+                 </EncryptedKey>
+               </ds:KeyInfo>
+               <CipherData>
+                 <CipherValue>
+                 </CipherValue>
+               </CipherData>
+</EncryptedData>

--- a/tests/fixtures/xmlenc/aleksey-xmlenc-01/enc-aes256cbc-keyname.tmpl
+++ b/tests/fixtures/xmlenc/aleksey-xmlenc-01/enc-aes256cbc-keyname.tmpl
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EncryptedData xmlns="http://www.w3.org/2001/04/xmlenc#" MimeType="text/plain">
+  <EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#aes256-cbc" />
+  <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+     <KeyName>
+	test-aes256
+     </KeyName>
+  </KeyInfo>   
+  <CipherData>
+     <CipherValue/>
+  </CipherData>
+</EncryptedData>

--- a/tests/fixtures/xmlenc/aleksey-xmlenc-01/enc-aes256gcm-keyname.tmpl
+++ b/tests/fixtures/xmlenc/aleksey-xmlenc-01/enc-aes256gcm-keyname.tmpl
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EncryptedData xmlns="http://www.w3.org/2001/04/xmlenc#"
+               xmlns:xenc11="http://www.w3.org/2009/xmlenc11#"
+               MimeType="text/plain">
+  <EncryptionMethod Algorithm="http://www.w3.org/2009/xmlenc11#aes256-gcm"/>
+  <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+    <KeyName>test-aes256</KeyName>
+  </KeyInfo>
+  <CipherData>
+    <CipherValue/>
+  </CipherData>
+</EncryptedData>

--- a/tests/fixtures_smoke.rs
+++ b/tests/fixtures_smoke.rs
@@ -180,7 +180,7 @@ fn fixture_file_count_matches_expected() {
         ("c14n", 41),
         ("xmldsig", 78),
         ("saml", 2),
-        ("xmlenc", 404),
+        ("xmlenc", 410),
     ];
 
     for (corpus, expected_count) in expected {

--- a/tests/xmlenc_encrypt_integration.rs
+++ b/tests/xmlenc_encrypt_integration.rs
@@ -1,0 +1,555 @@
+//! XMLEnc encryption pipeline integration and donor-template coverage.
+
+#![cfg(feature = "xmlenc")]
+
+use std::fs;
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use roxmltree::Node;
+use rsa::{
+    RsaPrivateKey, RsaPublicKey,
+    pkcs8::{DecodePrivateKey, DecodePublicKey},
+};
+use xml_sec::xmlenc::{
+    DataEncryptionAlgorithm, DecryptedContent, DocumentEncryptionOptions, EncryptedDataBuilder,
+    EncryptedDataType, EncryptionRecipient, KekDecryptor, KeyTransportAlgorithm, KeyWrapAlgorithm,
+    OaepDigestAlgorithm, PrivateKeyDecryptor, RsaOaepParameters, SymmetricKeyDecryptor,
+    XmlEncError, decrypt, decrypt_document, parse_encrypted_data,
+};
+
+const DONOR_DIR: &str = "tests/fixtures/xmlenc/aleksey-xmlenc-01";
+const RSA_2048_PRIVATE: &str = "tests/fixtures/keys/rsa/rsa-2048-key.pem";
+const RSA_2048_PUBLIC: &str = "tests/fixtures/keys/rsa/rsa-2048-pubkey.pem";
+const RSA_4096_PRIVATE: &str = "tests/fixtures/keys/rsa/rsa-4096-key.pem";
+const RSA_4096_PUBLIC: &str = "tests/fixtures/keys/rsa/rsa-4096-pubkey.pem";
+
+fn private_key(path: &str) -> RsaPrivateKey {
+    RsaPrivateKey::from_pkcs8_pem(&fs::read_to_string(path).expect("RSA fixture must load"))
+        .expect("RSA fixture must contain a PKCS#8 private key")
+}
+
+fn public_key(path: &str) -> RsaPublicKey {
+    RsaPublicKey::from_public_key_pem(
+        &fs::read_to_string(path).expect("RSA public-key fixture must load"),
+    )
+    .expect("RSA fixture must contain an SPKI public key")
+}
+
+fn method_algorithm(node: Node<'_, '_>) -> String {
+    node.attribute("Algorithm")
+        .expect("donor EncryptionMethod must declare Algorithm")
+        .to_owned()
+}
+
+fn donor_key_name(document: &roxmltree::Document<'_>) -> String {
+    document
+        .descendants()
+        .find(|node| node.tag_name().name() == "KeyName")
+        .and_then(|node| node.text())
+        .map(str::trim)
+        .expect("donor template must contain KeyName")
+        .to_owned()
+}
+
+#[test]
+fn donor_direct_templates_match_generated_algorithm_and_key_contracts() {
+    // Each imported xmlsec1 template is an independent schema oracle for the
+    // algorithm URI and KeyName placement emitted by the public builder.
+    for (name, algorithm, key) in [
+        (
+            "enc-aes128cbc-keyname",
+            DataEncryptionAlgorithm::Aes128Cbc,
+            vec![0x11; 16],
+        ),
+        (
+            "enc-aes128gcm-keyname",
+            DataEncryptionAlgorithm::Aes128Gcm,
+            vec![0x22; 16],
+        ),
+        (
+            "enc-aes256cbc-keyname",
+            DataEncryptionAlgorithm::Aes256Cbc,
+            vec![0x33; 32],
+        ),
+        (
+            "enc-aes256gcm-keyname",
+            DataEncryptionAlgorithm::Aes256Gcm,
+            vec![0x44; 32],
+        ),
+    ] {
+        let template = fs::read_to_string(format!("{DONOR_DIR}/{name}.tmpl"))
+            .expect("tracked donor template must load");
+        let template_document =
+            roxmltree::Document::parse(&template).expect("donor template must be XML");
+        let template_method = template_document
+            .descendants()
+            .find(|node| node.tag_name().name() == "EncryptionMethod")
+            .expect("donor template must contain EncryptionMethod");
+        let generated = EncryptedDataBuilder::new(algorithm)
+            .direct_key(key.clone())
+            .direct_key_name(if algorithm.key_len() == 16 {
+                "test-aes128"
+            } else {
+                "test-aes256"
+            })
+            .encrypt_binary(format!("{name} plaintext").as_bytes())
+            .expect("donor-shaped direct encryption must succeed");
+        let generated_data = parse_encrypted_data(&generated.encrypted_data_xml)
+            .expect("generated EncryptedData must parse");
+
+        assert_eq!(
+            generated_data.encryption_method.algorithm,
+            method_algorithm(template_method),
+            "{name}"
+        );
+        assert_eq!(
+            generated_data.key_name.as_deref(),
+            Some(donor_key_name(&template_document).as_str()),
+            "{name}"
+        );
+        assert_eq!(
+            decrypt(
+                &generated.encrypted_data_xml,
+                &SymmetricKeyDecryptor::new(key)
+            )
+            .expect("generated donor-shaped ciphertext must decrypt"),
+            DecryptedContent::Bytes(format!("{name} plaintext").into_bytes()),
+            "{name}"
+        );
+    }
+}
+
+#[test]
+fn donor_rsa_templates_match_legacy_and_xmlenc11_oaep_contracts() {
+    // The two donor templates cover an OAEP label on the legacy URI and
+    // independently configurable digest/MGF algorithms on the 1.1 URI.
+    let public = public_key(RSA_4096_PUBLIC);
+    let private = private_key(RSA_4096_PRIVATE);
+    let cases = [
+        (
+            "enc-aes256-kt-rsa_oaep_sha1-params",
+            RsaOaepParameters::legacy().label(b"12345678".to_vec()),
+        ),
+        (
+            "enc-aes256-kt-rsa_oaep_enc11_sha512_mgf1_sha512",
+            RsaOaepParameters::xmlenc11(OaepDigestAlgorithm::Sha512, OaepDigestAlgorithm::Sha512),
+        ),
+    ];
+
+    for (name, parameters) in cases {
+        let template = fs::read_to_string(format!("{DONOR_DIR}/{name}.tmpl"))
+            .expect("tracked donor template must load");
+        let template_document =
+            roxmltree::Document::parse(&template).expect("donor template must be XML");
+        let template_methods = template_document
+            .descendants()
+            .filter(|node| node.tag_name().name() == "EncryptionMethod")
+            .collect::<Vec<_>>();
+        assert_eq!(template_methods.len(), 2, "{name}");
+        let generated = EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes256Cbc)
+            .encryption_type(EncryptedDataType::Content)
+            .id("ED")
+            .add_recipient(
+                EncryptionRecipient::rsa_oaep(public.clone())
+                    .oaep_parameters(parameters)
+                    .key_name("TestKeyName-rsa-4096"),
+            )
+            .encrypt_xml("<PaymentInfo><Name>John Smith</Name></PaymentInfo>")
+            .expect("donor-shaped OAEP encryption must succeed");
+        let generated_data = parse_encrypted_data(&generated.encrypted_data_xml)
+            .expect("generated EncryptedData must parse");
+
+        assert_eq!(
+            generated_data.encryption_method.algorithm,
+            method_algorithm(template_methods[0]),
+            "{name}"
+        );
+        assert_eq!(
+            generated_data.encrypted_keys[0].encryption_method.algorithm,
+            method_algorithm(template_methods[1]),
+            "{name}"
+        );
+        let donor_digest = template_methods[1]
+            .children()
+            .find(|node| node.tag_name().name() == "DigestMethod")
+            .and_then(|node| node.attribute("Algorithm"))
+            .map(str::to_owned);
+        let donor_mgf = template_methods[1]
+            .children()
+            .find(|node| node.tag_name().name() == "MGF")
+            .and_then(|node| node.attribute("Algorithm"))
+            .map(str::to_owned);
+        let donor_label = template_methods[1]
+            .children()
+            .find(|node| node.tag_name().name() == "OAEPparams")
+            .and_then(|node| node.text())
+            .map(str::trim)
+            .map(|value| {
+                STANDARD
+                    .decode(value)
+                    .expect("donor OAEP label must be base64")
+            });
+        assert_eq!(
+            generated_data.encrypted_keys[0]
+                .encryption_method
+                .oaep_digest,
+            donor_digest,
+            "{name}"
+        );
+        assert_eq!(
+            generated_data.encrypted_keys[0]
+                .encryption_method
+                .mgf_algorithm,
+            donor_mgf,
+            "{name}"
+        );
+        assert_eq!(
+            generated_data.encrypted_keys[0]
+                .encryption_method
+                .oaep_params,
+            donor_label,
+            "{name}"
+        );
+        assert_eq!(
+            generated_data.encrypted_keys[0].key_name.as_deref(),
+            Some(donor_key_name(&template_document).as_str()),
+            "{name}"
+        );
+        assert_eq!(
+            decrypt(
+                &generated.encrypted_data_xml,
+                &PrivateKeyDecryptor::new(private.clone())
+            )
+            .expect("generated donor-shaped OAEP ciphertext must decrypt"),
+            DecryptedContent::Xml("<PaymentInfo><Name>John Smith</Name></PaymentInfo>".into()),
+            "{name}"
+        );
+    }
+}
+
+#[test]
+fn every_supported_oaep_digest_and_mgf_combination_round_trips() {
+    // Digest and MGF are independent in XMLEnc 1.1; this matrix guards against
+    // accidentally dispatching one parameter for both RSA OAEP hash roles.
+    let private = private_key(RSA_2048_PRIVATE);
+    let public = RsaPublicKey::from(&private);
+    let digests = [
+        OaepDigestAlgorithm::Sha1,
+        OaepDigestAlgorithm::Sha256,
+        OaepDigestAlgorithm::Sha384,
+        OaepDigestAlgorithm::Sha512,
+    ];
+    for digest in digests {
+        for mgf_digest in digests {
+            let encrypted = EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm)
+                .add_recipient(
+                    EncryptionRecipient::rsa_oaep(public.clone())
+                        .oaep_parameters(RsaOaepParameters::xmlenc11(digest, mgf_digest)),
+                )
+                .encrypt_binary(b"OAEP matrix")
+                .expect("supported OAEP combination must encrypt");
+            assert_eq!(
+                decrypt(
+                    &encrypted.encrypted_data_xml,
+                    &PrivateKeyDecryptor::new(private.clone())
+                )
+                .expect("supported OAEP combination must decrypt"),
+                DecryptedContent::Bytes(b"OAEP matrix".to_vec()),
+                "digest={digest:?}, mgf={mgf_digest:?}"
+            );
+        }
+    }
+
+    for digest in digests {
+        let parameters = RsaOaepParameters {
+            algorithm: KeyTransportAlgorithm::RsaOaepMgf1p,
+            digest,
+            mgf_digest: OaepDigestAlgorithm::Sha1,
+            label: b"legacy label".to_vec(),
+        };
+        let encrypted = EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Cbc)
+            .add_recipient(
+                EncryptionRecipient::rsa_oaep(public.clone()).oaep_parameters(parameters),
+            )
+            .encrypt_binary(b"legacy OAEP digest matrix")
+            .expect("legacy OAEP digest with fixed MGF1-SHA1 must encrypt");
+        assert_eq!(
+            decrypt(
+                &encrypted.encrypted_data_xml,
+                &PrivateKeyDecryptor::new(private.clone())
+            )
+            .expect("legacy OAEP digest with fixed MGF1-SHA1 must decrypt"),
+            DecryptedContent::Bytes(b"legacy OAEP digest matrix".to_vec()),
+            "legacy digest={digest:?}"
+        );
+    }
+}
+
+#[test]
+fn one_session_key_is_recoverable_by_each_rsa_recipient() {
+    // Either recipient must independently recover the same generated session
+    // key even when its EncryptedKey is not first in document order.
+    let encrypted = EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes256Gcm)
+        .add_recipient(
+            EncryptionRecipient::rsa_oaep(public_key(RSA_2048_PUBLIC))
+                .recipient("primary")
+                .key_name("rsa-2048"),
+        )
+        .add_recipient(
+            EncryptionRecipient::rsa_oaep(public_key(RSA_4096_PUBLIC))
+                .recipient("secondary")
+                .key_name("rsa-4096"),
+        )
+        .encrypt_xml("<secret>shared</secret>")
+        .expect("multi-recipient encryption must succeed");
+    let parsed = parse_encrypted_data(&encrypted.encrypted_data_xml)
+        .expect("multi-recipient output must parse");
+    assert_eq!(parsed.encrypted_keys.len(), 2);
+    assert_eq!(
+        parsed.encrypted_keys[0].recipient.as_deref(),
+        Some("primary")
+    );
+    assert_eq!(
+        parsed.encrypted_keys[1].recipient.as_deref(),
+        Some("secondary")
+    );
+
+    for key_path in [RSA_2048_PRIVATE, RSA_4096_PRIVATE] {
+        assert_eq!(
+            decrypt(
+                &encrypted.encrypted_data_xml,
+                &PrivateKeyDecryptor::new(private_key(key_path))
+            )
+            .expect("each recipient must decrypt the shared content"),
+            DecryptedContent::Xml("<secret>shared</secret>".into()),
+            "{key_path}"
+        );
+    }
+}
+
+#[test]
+fn both_aes_key_wrap_sizes_cover_both_content_key_sizes() {
+    // RFC 3394 accepts either supported content-key width under either
+    // supported KEK width; all four combinations must remain interoperable.
+    for (wrap, kek) in [
+        (KeyWrapAlgorithm::AesKw128, vec![0x81; 16]),
+        (KeyWrapAlgorithm::AesKw256, vec![0x82; 32]),
+    ] {
+        for algorithm in [
+            DataEncryptionAlgorithm::Aes128Cbc,
+            DataEncryptionAlgorithm::Aes256Gcm,
+        ] {
+            let encrypted = EncryptedDataBuilder::new(algorithm)
+                .recipient_aes_kw(kek.clone(), wrap)
+                .encrypt_binary(b"wrapped content key")
+                .expect("supported AES-KW combination must encrypt");
+            assert_eq!(
+                decrypt(
+                    &encrypted.encrypted_data_xml,
+                    &KekDecryptor::new(kek.clone())
+                )
+                .expect("supported AES-KW combination must decrypt"),
+                DecryptedContent::Bytes(b"wrapped content key".to_vec())
+            );
+        }
+    }
+}
+
+#[test]
+fn document_encryption_selects_one_id_and_preserves_surrounding_xml() {
+    // Element and Content replacement must preserve unrelated siblings,
+    // inherited namespace context, and the selected element's own attributes.
+    let key = [0x91; 16];
+    let document = "<root xmlns:p=\"urn:test\"><before/><p:target Id=\"chosen\" role=\"secret\"><p:item/>text</p:target><after/></root>";
+    for encrypted_type in [EncryptedDataType::Element, EncryptedDataType::Content] {
+        let encrypted = EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm)
+            .encryption_type(encrypted_type)
+            .direct_key(key)
+            .id("encrypted-target")
+            .encrypt_document(
+                document,
+                DocumentEncryptionOptions {
+                    element_id: Some("chosen"),
+                    allow_dtd: false,
+                },
+            )
+            .expect("selected document node must encrypt");
+        assert!(encrypted.contains("<before/>"));
+        assert!(encrypted.contains("<after/>"));
+        assert_eq!(
+            decrypt_document(
+                &encrypted,
+                Some("encrypted-target"),
+                &SymmetricKeyDecryptor::new(key)
+            )
+            .expect("selected document node must decrypt"),
+            document
+        );
+    }
+}
+
+#[test]
+fn saml_encrypted_assertion_round_trips_through_rsa_transport() {
+    // A SAML EncryptedAssertion contains an XMLEnc EncryptedData child; this
+    // verifies assertion namespaces, attributes, and subject data end to end.
+    let assertion = concat!(
+        "<saml:Assertion xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ",
+        "ID=\"assertion-1\" Version=\"2.0\" IssueInstant=\"2026-07-21T00:00:00Z\">",
+        "<saml:Issuer>https://idp.example</saml:Issuer>",
+        "<saml:Subject><saml:NameID>alice@example.com</saml:NameID></saml:Subject>",
+        "</saml:Assertion>"
+    );
+    let private = private_key(RSA_2048_PRIVATE);
+    let encrypted = EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes256Gcm)
+        .add_recipient(EncryptionRecipient::rsa_oaep(RsaPublicKey::from(&private)))
+        .encrypt_xml(assertion)
+        .expect("SAML Assertion must encrypt");
+    let response = format!(
+        "<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\"><saml:EncryptedAssertion>{}</saml:EncryptedAssertion></samlp:Response>",
+        encrypted.encrypted_data_xml
+    );
+    let decrypted = decrypt_document(&response, None, &PrivateKeyDecryptor::new(private))
+        .expect("SAML EncryptedAssertion child must decrypt");
+    assert_eq!(
+        decrypted,
+        format!(
+            "<samlp:Response xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\"><saml:EncryptedAssertion>{assertion}</saml:EncryptedAssertion></samlp:Response>"
+        )
+    );
+}
+
+#[test]
+fn invalid_targets_configuration_and_keys_fail_closed() {
+    // Malformed XML, ambiguous IDs, missing IDs, incompatible key sources, and
+    // wrong KEKs must fail explicitly rather than processing unintended data.
+    let key = [0xa1; 16];
+    let builder = EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm).direct_key(key);
+    assert!(matches!(
+        builder.encrypt_xml("<root><unclosed></root>"),
+        Err(XmlEncError::XmlParse(_))
+    ));
+    assert!(matches!(
+        builder
+            .clone()
+            .encryption_type(EncryptedDataType::Content)
+            .encrypt_xml("<unclosed>"),
+        Err(XmlEncError::XmlParse(_))
+    ));
+    assert!(matches!(
+        builder.encrypt_document(
+            "<root><unclosed></root>",
+            DocumentEncryptionOptions::default()
+        ),
+        Err(XmlEncError::XmlParse(_))
+    ));
+    assert!(matches!(
+        builder.encrypt_document(
+            "<root><a Id=\"same\"/><b id=\"same\"/></root>",
+            DocumentEncryptionOptions {
+                element_id: Some("same"),
+                allow_dtd: false,
+            }
+        ),
+        Err(XmlEncError::AmbiguousEncryptionTarget)
+    ));
+    assert!(matches!(
+        builder.encrypt_document(
+            "<root/>",
+            DocumentEncryptionOptions {
+                element_id: Some("missing"),
+                allow_dtd: false,
+            }
+        ),
+        Err(XmlEncError::EncryptionTargetNotFound)
+    ));
+
+    let incompatible = EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm)
+        .direct_key(key)
+        .add_recipient(EncryptionRecipient::aes_key_wrap(
+            [0xb2; 16],
+            KeyWrapAlgorithm::AesKw128,
+        ))
+        .encrypt_binary(b"must not encrypt");
+    assert!(matches!(
+        incompatible,
+        Err(XmlEncError::InvalidEncryptionConfig(_))
+    ));
+
+    let encrypted = EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm)
+        .recipient_aes_kw([0xc3; 16], KeyWrapAlgorithm::AesKw128)
+        .encrypt_binary(b"secret")
+        .expect("valid KEK must encrypt");
+    assert!(matches!(
+        decrypt(
+            &encrypted.encrypted_data_xml,
+            &KekDecryptor::new([0xd4; 16])
+        ),
+        Err(XmlEncError::KeyWrapIntegrity)
+    ));
+}
+
+#[test]
+fn tampered_generated_gcm_ciphertext_fails_authentication() {
+    // A generated GCM value must authenticate its ciphertext and tag; changing
+    // one base64 character must never yield unauthenticated plaintext.
+    let key = [0xf6; 16];
+    let encrypted = EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm)
+        .direct_key(key)
+        .encrypt_binary(b"authenticated plaintext")
+        .expect("GCM encryption must succeed");
+    let mut tampered = encrypted.encrypted_data_xml;
+    let value_end = tampered
+        .find("</xenc:CipherValue>")
+        .expect("generated output must contain CipherValue");
+    let index = value_end - 2;
+    let replacement = if &tampered[index..=index] == "A" {
+        "B"
+    } else {
+        "A"
+    };
+    tampered.replace_range(index..=index, replacement);
+
+    assert!(matches!(
+        decrypt(&tampered, &SymmetricKeyDecryptor::new(key)),
+        Err(XmlEncError::AeadAuthenticationFailed)
+    ));
+}
+
+#[test]
+fn generated_metadata_is_xml_escaped_and_legacy_mgf_is_restricted() {
+    // Caller metadata must remain data after serialization, and the legacy
+    // OAEP URI cannot falsely advertise a configurable non-SHA1 MGF.
+    let encrypted = EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm)
+        .id("encrypted<&\"")
+        .add_recipient(
+            EncryptionRecipient::aes_key_wrap([0xe5; 16], KeyWrapAlgorithm::AesKw128)
+                .recipient("recipient<&\"")
+                .key_name("key<&"),
+        )
+        .encrypt_binary(b"metadata")
+        .expect("metadata must serialize safely");
+    let parsed =
+        parse_encrypted_data(&encrypted.encrypted_data_xml).expect("escaped metadata must parse");
+    assert_eq!(parsed.id.as_deref(), Some("encrypted<&\""));
+    assert_eq!(
+        parsed.encrypted_keys[0].recipient.as_deref(),
+        Some("recipient<&\"")
+    );
+    assert_eq!(parsed.encrypted_keys[0].key_name.as_deref(), Some("key<&"));
+
+    let invalid_legacy = RsaOaepParameters {
+        algorithm: KeyTransportAlgorithm::RsaOaepMgf1p,
+        digest: OaepDigestAlgorithm::Sha256,
+        mgf_digest: OaepDigestAlgorithm::Sha256,
+        label: Vec::new(),
+    };
+    assert!(matches!(
+        EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm)
+            .add_recipient(
+                EncryptionRecipient::rsa_oaep(public_key(RSA_2048_PUBLIC))
+                    .oaep_parameters(invalid_legacy)
+            )
+            .encrypt_binary(b"invalid legacy MGF"),
+        Err(XmlEncError::InvalidEncryptionConfig(_))
+    ));
+}

--- a/tests/xmlenc_encrypt_integration.rs
+++ b/tests/xmlenc_encrypt_integration.rs
@@ -389,6 +389,31 @@ fn document_encryption_selects_one_id_and_preserves_surrounding_xml() {
 }
 
 #[test]
+fn content_encryption_preserves_cdata_with_closing_markers() {
+    // A `</` sequence inside CDATA must not be mistaken for the selected
+    // element's closing tag when calculating the content replacement range.
+    let key = [0x92; 16];
+    let document = "<root><target Id=\"chosen\"><![CDATA[</not-a-tag>]]></target></root>";
+    let encrypted = EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm)
+        .encryption_type(EncryptedDataType::Content)
+        .direct_key(key)
+        .encrypt_document(
+            document,
+            DocumentEncryptionOptions {
+                element_id: Some("chosen"),
+                allow_dtd: false,
+            },
+        )
+        .expect("CDATA content containing a closing marker must encrypt");
+
+    assert_eq!(
+        decrypt_document(&encrypted, None, &SymmetricKeyDecryptor::new(key))
+            .expect("CDATA content containing a closing marker must decrypt"),
+        document
+    );
+}
+
+#[test]
 fn saml_encrypted_assertion_round_trips_through_rsa_transport() {
     // A SAML EncryptedAssertion contains an XMLEnc EncryptedData child; this
     // verifies assertion namespaces, attributes, and subject data end to end.

--- a/tests/xmlenc_encrypt_xmlsec1.rs
+++ b/tests/xmlenc_encrypt_xmlsec1.rs
@@ -1,0 +1,171 @@
+//! External decryption interoperability for XMLEnc produced by xml-sec.
+
+#![cfg(feature = "xmlenc")]
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+    sync::atomic::{AtomicU64, Ordering},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use rsa::{RsaPublicKey, pkcs8::DecodePublicKey};
+use xml_sec::xmlenc::{
+    DataEncryptionAlgorithm, EncryptedDataBuilder, EncryptionRecipient, OaepDigestAlgorithm,
+    RsaOaepParameters,
+};
+
+static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+struct TemporaryFile {
+    path: PathBuf,
+}
+
+impl TemporaryFile {
+    fn path(label: &str, extension: &str) -> Self {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time must be after the Unix epoch")
+            .as_nanos();
+        let sequence = TEMP_FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
+        Self {
+            path: std::env::temp_dir().join(format!(
+                "xml-sec-{label}-{}-{timestamp}-{sequence}.{extension}",
+                std::process::id()
+            )),
+        }
+    }
+
+    fn write(label: &str, extension: &str, contents: &[u8]) -> Self {
+        let file = Self::path(label, extension);
+        fs::write(&file.path, contents)
+            .unwrap_or_else(|error| panic!("failed to write {}: {error}", file.path.display()));
+        file
+    }
+}
+
+impl Drop for TemporaryFile {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+fn xmlsec1_version_supports_interop(version: &str) -> bool {
+    version
+        .split_whitespace()
+        .find_map(|token| {
+            let mut components = token.split('.');
+            Some((
+                components.next()?.parse::<u16>().ok()?,
+                components.next()?.parse::<u16>().ok()?,
+                components.next()?.parse::<u16>().ok()?,
+            ))
+        })
+        .is_some_and(|version| version >= (1, 3, 8))
+}
+
+fn xmlsec1_is_available() -> bool {
+    let Ok(output) = Command::new("xmlsec1").arg("--version").output() else {
+        return false;
+    };
+    output.status.success()
+        && std::str::from_utf8(&output.stdout).is_ok_and(xmlsec1_version_supports_interop)
+}
+
+fn decrypt_with_xmlsec1(encrypted_xml: &str, key_option: &str, key_path: &Path) -> Vec<u8> {
+    let input = TemporaryFile::write("xmlenc-input", "xml", encrypted_xml.as_bytes());
+    let output = TemporaryFile::path("xmlenc-output", "data");
+    let command_output = Command::new("xmlsec1")
+        .arg("decrypt")
+        .arg("--lax-key-search")
+        .arg(key_option)
+        .arg(key_path)
+        .arg("--output")
+        .arg(&output.path)
+        .arg(&input.path)
+        .output()
+        .expect("xmlsec1 must be installed for XMLEnc interoperability tests");
+    assert!(
+        command_output.status.success(),
+        "xmlsec1 rejected xml-sec ciphertext:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&command_output.stdout),
+        String::from_utf8_lossy(&command_output.stderr)
+    );
+    fs::read(&output.path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", output.path.display()))
+}
+
+#[test]
+fn xmlsec1_version_gate_accepts_ci_version() {
+    assert!(!xmlsec1_version_supports_interop("xmlsec1 1.3.7 (openssl)"));
+    assert!(xmlsec1_version_supports_interop("xmlsec1 1.3.8 (openssl)"));
+    assert!(xmlsec1_version_supports_interop("xmlsec1 1.3.12 (openssl)"));
+}
+
+#[test]
+fn xmlsec1_decrypts_direct_aes_gcm_from_xml_sec() {
+    // This validates nonce/tag framing and direct KeyName XML against an
+    // independent implementation rather than our reciprocal decrypt path.
+    if !xmlsec1_is_available() {
+        eprintln!("skipping XMLEnc interop: xmlsec1 >= 1.3.8 is not installed");
+        return;
+    }
+    let key = [0x4a; 16];
+    let plaintext = b"xmlsec1 direct AES-GCM interoperability";
+    let encrypted = EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes128Gcm)
+        .direct_key(key)
+        .direct_key_name("interop-aes")
+        .encrypt_binary(plaintext)
+        .expect("direct AES-GCM encryption must succeed");
+    let key_file = TemporaryFile::write("xmlenc-aes-key", "bin", &key);
+
+    assert_eq!(
+        decrypt_with_xmlsec1(
+            &encrypted.encrypted_data_xml,
+            "--aeskey:interop-aes",
+            &key_file.path
+        ),
+        plaintext
+    );
+}
+
+#[test]
+fn xmlsec1_decrypts_rsa_oaep_wrapped_aes_cbc_from_xml_sec() {
+    // This covers generated session-key transport, OAEP digest/MGF metadata,
+    // nested EncryptedKey lookup, and XMLEnc CBC random-padding framing.
+    if !xmlsec1_is_available() {
+        eprintln!("skipping XMLEnc interop: xmlsec1 >= 1.3.8 is not installed");
+        return;
+    }
+    let public_key_path = Path::new("tests/fixtures/keys/rsa/rsa-2048-pubkey.pem");
+    let private_key_path = Path::new("tests/fixtures/keys/rsa/rsa-2048-key.pem");
+    let public_key = RsaPublicKey::from_public_key_pem(
+        &fs::read_to_string(public_key_path).expect("RSA public-key fixture must load"),
+    )
+    .expect("RSA public-key fixture must contain SPKI PEM");
+    let plaintext = b"xmlsec1 RSA-OAEP and AES-CBC interoperability";
+    let encrypted = EncryptedDataBuilder::new(DataEncryptionAlgorithm::Aes256Cbc)
+        .add_recipient(
+            EncryptionRecipient::rsa_oaep(public_key)
+                .oaep_parameters(
+                    RsaOaepParameters::xmlenc11(
+                        OaepDigestAlgorithm::Sha256,
+                        OaepDigestAlgorithm::Sha256,
+                    )
+                    .label(b"xmlsec1-interop-label".to_vec()),
+                )
+                .key_name("interop-rsa"),
+        )
+        .encrypt_binary(plaintext)
+        .expect("RSA-OAEP encryption must succeed");
+
+    assert_eq!(
+        decrypt_with_xmlsec1(
+            &encrypted.encrypted_data_xml,
+            "--privkey-pem:interop-rsa",
+            private_key_path
+        ),
+        plaintext
+    );
+}


### PR DESCRIPTION
## Summary

- add a complete pure-Rust XMLEnc encryption pipeline for binary data, XML elements, and XML content
- support AES-128/256-CBC, AES-128/256-GCM, RSA-OAEP 1.0/1.1, AES-128/256 Key Wrap, and multiple recipients
- add bounded document replacement, donor fixtures, SAML coverage, documentation, and a runnable example

## Security

- use the operating-system RNG for content keys, IVs, nonces, and RSA-OAEP
- reject malformed XML, incompatible key sources, invalid key sizes, excessive inputs and recipients, and unsupported legacy configurations
- keep external resource retrieval and C/C++ FFI outside the runtime path

## Testing

- `cargo nextest run --all-features --no-fail-fast` (`618 passed`, `0 skipped`)
- `cargo test --doc --all-features` (`4 passed`)
- `cargo check --all-features`
- `cargo check --no-default-features --features xmlenc`
- `cargo check --examples`
- `cargo check --examples --features xmlenc`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo package --allow-dirty`
- external decryption interoperability with `xmlsec1 1.3.12`

Closes #95
